### PR TITLE
feat: add customizable context parameter description for tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcpcat"
-version = "0.1.8"
+version = "0.1.9"
 description = "Analytics Tool for MCP Servers - provides insights into MCP tool usage patterns"
 authors = [
     { name = "MCPCat", email = "support@mcpcat.io" },

--- a/src/mcpcat/modules/compatibility.py
+++ b/src/mcpcat/modules/compatibility.py
@@ -30,35 +30,39 @@ class MCPServerProtocol(Protocol):
 
 def is_community_fastmcp_server(server: Any) -> bool:
     """Check if the server is a community FastMCP instance.
-    
+
     Community FastMCP comes from the 'fastmcp' package.
+    Supports FastMCP subclasses like FastMCPOpenAPI, FastMCPProxy, etc.
     """
     # Check by class name and module
     class_name = server.__class__.__name__
     module_name = server.__class__.__module__
-    
-    # Community FastMCP has class name 'FastMCP' and module starts with 'fastmcp'
+
+    # Community FastMCP has class name containing 'FastMCP' and module starts with 'fastmcp'
+    # This supports FastMCPOpenAPI, FastMCPProxy, and other subclasses
     return (
-        class_name == "FastMCP" and 
+        "FastMCP" in class_name and
         module_name.startswith("fastmcp") and
-        hasattr(server, "_mcp_server") and 
+        hasattr(server, "_mcp_server") and
         hasattr(server, "_tool_manager")
     )
 
 def is_official_fastmcp_server(server: Any) -> bool:
     """Check if the server is an official FastMCP instance.
-    
+
     Official FastMCP comes from the 'mcp.server.fastmcp' module.
+    Supports FastMCP subclasses like FastMCPOpenAPI, FastMCPProxy, etc.
     """
     # Check by class name and module
     class_name = server.__class__.__name__
     module_name = server.__class__.__module__
-    
-    # Official FastMCP has class name 'FastMCP' and module 'mcp.server.fastmcp'
+
+    # Official FastMCP has class name containing 'FastMCP' and module 'mcp.server.fastmcp'
+    # This supports FastMCPOpenAPI, FastMCPProxy, and other subclasses
     return (
-        class_name == "FastMCP" and 
+        "FastMCP" in class_name and
         module_name.startswith("mcp.server.fastmcp") and
-        hasattr(server, "_mcp_server") and 
+        hasattr(server, "_mcp_server") and
         hasattr(server, "_tool_manager")
     )
 

--- a/src/mcpcat/modules/constants.py
+++ b/src/mcpcat/modules/constants.py
@@ -3,3 +3,4 @@ LOG_PATH = "mcpcat.log"  # Default log file path
 SESSION_ID_PREFIX = "ses"
 EVENT_ID_PREFIX = "evt"
 MCPCAT_API_URL = "https://api.mcpcat.io"  # Default API URL for MCPCat events
+DEFAULT_CONTEXT_DESCRIPTION = "Describe why you are calling this tool and how it fits into your overall task"

--- a/src/mcpcat/modules/context_parameters.py
+++ b/src/mcpcat/modules/context_parameters.py
@@ -3,7 +3,9 @@
 from typing import Any
 
 
-def add_context_parameter_to_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def add_context_parameter_to_tools(
+    tools: list[dict[str, Any]], custom_context_description: str
+) -> list[dict[str, Any]]:
     """Add context parameter to tool schemas."""
     modified_tools = []
 
@@ -13,7 +15,7 @@ def add_context_parameter_to_tools(tools: list[dict[str, Any]]) -> list[dict[str
 
         if "inputSchema" in modified_tool:
             modified_tool["inputSchema"] = add_context_parameter_to_schema(
-                modified_tool["inputSchema"]
+                modified_tool["inputSchema"], custom_context_description
             )
 
         modified_tools.append(modified_tool)
@@ -21,7 +23,9 @@ def add_context_parameter_to_tools(tools: list[dict[str, Any]]) -> list[dict[str
     return modified_tools
 
 
-def add_context_parameter_to_schema(schema: dict[str, Any]) -> dict[str, Any]:
+def add_context_parameter_to_schema(
+    schema: dict[str, Any], custom_context_description: str
+) -> dict[str, Any]:
     """Add context parameter to a JSON schema."""
     # Create a copy to avoid modifying original
     modified_schema = schema.copy()
@@ -36,7 +40,7 @@ def add_context_parameter_to_schema(schema: dict[str, Any]) -> dict[str, Any]:
     # Add context parameter
     modified_schema["properties"]["context"] = {
         "type": "string",
-        "description": "Describe why you are calling this tool and how it fits into your overall task",
+        "description": custom_context_description,
     }
 
     # Add to required fields

--- a/src/mcpcat/modules/overrides/community/tool_manager.py
+++ b/src/mcpcat/modules/overrides/community/tool_manager.py
@@ -79,6 +79,7 @@ def patch_community_fastmcp_tool_manager(server: Any) -> None:
 def patch_existing_tools(server: FastMCP) -> None:
     """Modify existing tools to include the context parameter."""
     try:
+        data = get_server_tracking_data(server._mcp_server)
         tool_manager = server._tool_manager
         if not hasattr(tool_manager, "_tools"):
             write_to_log("No _tools dictionary found on tool manager")
@@ -102,7 +103,7 @@ def patch_existing_tools(server: FastMCP) -> None:
             # Always overwrite the context property with MCPCat's version
             tool.parameters["properties"]["context"] = {
                 "type": "string",
-                "description": "Describe why you are calling this tool and how it fits into your overall task"
+                "description": data.options.custom_context_description,
             }
 
             # Add to required array
@@ -168,7 +169,7 @@ def patch_add_tool_fn(server: FastMCP) -> None:
                         # Always overwrite the context property with MCPCat's version
                         tool.parameters["properties"]["context"] = {
                             "type": "string",
-                            "description": "Describe why you are calling this tool and how it fits into your overall task"
+                            "description": data.options.custom_context_description
                         }
 
                         # Add to required array

--- a/src/mcpcat/modules/overrides/mcp_server.py
+++ b/src/mcpcat/modules/overrides/mcp_server.py
@@ -120,7 +120,7 @@ def override_lowlevel_mcp_server(server: Server, data: MCPCatData) -> None:
 
                         tool.inputSchema["properties"]["context"] = {
                             "type": "string",
-                            "description": "Describe why you are calling this tool and how it fits into your overall task",
+                            "description": data.options.custom_context_description,
                         }
 
                         # Add context to required array if it exists

--- a/src/mcpcat/modules/overrides/official/monkey_patch.py
+++ b/src/mcpcat/modules/overrides/official/monkey_patch.py
@@ -444,7 +444,7 @@ def patch_fastmcp_tool_manager(server: Any, mcpcat_data: MCPCatData) -> bool:
 
                                     tool.parameters["properties"]["context"] = {
                                         "type": "string",
-                                        "description": "Describe why you are calling this tool and how it fits into your overall task",
+                                        "description": current_data.options.custom_context_description,
                                     }
 
                                     # Add to required array

--- a/src/mcpcat/types.py
+++ b/src/mcpcat/types.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, Optional, Set, TypedDict, Literal, Union
 from mcpcat_api import PublishEventRequest
 from pydantic import BaseModel
 
+from mcpcat.modules.constants import DEFAULT_CONTEXT_DESCRIPTION
+
 # Type alias for identify function
 IdentifyFunction = Callable[[dict[str, Any], Any], Optional["UserIdentity"]]
 # Type alias for redaction function
@@ -119,6 +121,7 @@ class MCPCatOptions:
     enable_report_missing: bool = True
     enable_tracing: bool = True
     enable_tool_call_context: bool = True
+    custom_context_description: str = DEFAULT_CONTEXT_DESCRIPTION
     identify: IdentifyFunction | None = None
     redact_sensitive_information: RedactionFunction | None = None
     exporters: dict[str, ExporterConfig] | None = None


### PR DESCRIPTION
  Allow users to customize the description text for the context parameter
  that's added to MCP tools. Defaults to the standard description but can
  be overridden via custom_context_description in MCPCatOptions.