### PR TITLE
Add event_tags and event_properties callbacks

### DIFF
--- a/src/mcpcat/__init__.py
+++ b/src/mcpcat/__init__.py
@@ -21,6 +21,8 @@ from .modules.compatibility import (
 from .modules.internal import set_server_tracking_data
 from .modules.logging import set_debug_mode, write_to_log
 from .types import (
+    EventPropertiesFunction,
+    EventTagsFunction,
     IdentifyFunction,
     MCPCatData,
     MCPCatOptions,
@@ -68,6 +70,18 @@ def track(
     Raises:
         ValueError: If neither project_id nor exporters are provided
         TypeError: If server is not a compatible MCP server instance
+
+    Example:
+        Attach custom metadata to every auto-captured event using
+        `event_tags` (string key-value pairs, validated) and
+        `event_properties` (flexible JSON). See
+        https://docs.mcpcat.io/sdk/event-tags-properties.
+
+        >>> import os, mcpcat
+        >>> mcpcat.track(server, "proj_abc123", mcpcat.MCPCatOptions(
+        ...     event_tags=lambda req, ctx: {"env": os.environ.get("APP_ENV", "dev")},
+        ...     event_properties=lambda req, ctx: {"feature_flags": ["dark_mode"]},
+        ... ))
     """
     if options is None:
         options = MCPCatOptions()
@@ -205,4 +219,7 @@ __all__ = [
     "IdentifyFunction",
     # Type for redaction functionality
     "RedactionFunction",
+    # Types for event metadata callbacks
+    "EventTagsFunction",
+    "EventPropertiesFunction",
 ]

--- a/src/mcpcat/modules/constants.py
+++ b/src/mcpcat/modules/constants.py
@@ -3,6 +3,7 @@ LOG_PATH = "mcpcat.log"  # Default log file path
 SESSION_ID_PREFIX = "ses"
 EVENT_ID_PREFIX = "evt"
 MCPCAT_API_URL = "https://api.mcpcat.io"  # Default API URL for MCPCat events
+MCPCAT_SOURCE = "mcpcat"  # Source attribution for telemetry exporters
 DEFAULT_CONTEXT_DESCRIPTION = "Explain why you are calling this tool and how it fits into the user's overall goal. This parameter is used for analytics and user intent tracking. YOU MUST provide 15-25 words (count carefully). NEVER use first person ('I', 'we', 'you') - maintain third-person perspective. NEVER include sensitive information such as credentials, passwords, or personal data. Example (20 words): \"Searching across the organization's repositories to find all open issues related to performance complaints and latency issues for team prioritization.\""
 
 # Maximum number of exceptions to capture in a cause chain

--- a/src/mcpcat/modules/exporters/datadog.py
+++ b/src/mcpcat/modules/exporters/datadog.py
@@ -1,14 +1,27 @@
 """Datadog exporter for MCPCat telemetry."""
 
 import json
+import re
 from datetime import datetime
 from typing import Dict, List, Any
 import requests
 
 from ...types import Event, DatadogExporterConfig
+from ...modules.constants import MCPCAT_SOURCE
 from ...modules.logging import write_to_log
 from . import Exporter
 from .trace_context import trace_context
+
+
+_DD_TAG_KEY_SANITIZE = re.compile(r"[\s:,]+")
+
+
+def _sanitize_dd_tag_key(key: str) -> str:
+    return _DD_TAG_KEY_SANITIZE.sub("_", key.lower())
+
+
+def _sanitize_dd_tag_value(value: str) -> str:
+    return value.replace(",", "_")
 
 
 class DatadogExporter(Exporter):
@@ -133,6 +146,15 @@ class DatadogExporter(Exporter):
         if event.is_error:
             tags.append("error:true")
 
+        tags.append(f"source:{MCPCAT_SOURCE}")
+
+        # Add customer-defined tags (namespaced to avoid collisions with reserved Datadog tags)
+        if getattr(event, "tags", None):
+            for key, value in event.tags.items():
+                tags.append(
+                    f"mcpcat.{_sanitize_dd_tag_key(key)}:{_sanitize_dd_tag_value(value)}"
+                )
+
         # Get timestamp in milliseconds
         timestamp_ms = (
             int(event.timestamp.timestamp() * 1000)
@@ -143,7 +165,7 @@ class DatadogExporter(Exporter):
         log: Dict[str, Any] = {
             "message": f"{event.event_type or 'unknown'} - {event.resource_name or 'unknown'}",
             "service": self.service,
-            "ddsource": "mcpcat",
+            "ddsource": MCPCAT_SOURCE,
             "ddtags": ",".join(tags),
             "timestamp": timestamp_ms,
             "status": "error" if event.is_error else "info",
@@ -166,6 +188,8 @@ class DatadogExporter(Exporter):
                 "server_version": event.server_version,
                 "is_error": event.is_error,
                 "error": event.error,
+                "tags": getattr(event, "tags", None),
+                "properties": getattr(event, "properties", None),
             },
         }
 

--- a/src/mcpcat/modules/exporters/otlp.py
+++ b/src/mcpcat/modules/exporters/otlp.py
@@ -1,11 +1,13 @@
 """OpenTelemetry Protocol (OTLP) exporter for MCPCat telemetry."""
 
+import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 import requests
 
 from ...types import Event, OTLPExporterConfig
+from ...modules.constants import MCPCAT_SOURCE
 from ...modules.logging import write_to_log
 from . import Exporter
 from .trace_context import trace_context
@@ -171,7 +173,9 @@ class OTLPExporter(Exporter):
         Returns:
             List of attribute key-value pairs
         """
-        attributes = []
+        attributes: List[Dict[str, Any]] = [
+            {"key": "source", "value": {"stringValue": MCPCAT_SOURCE}},
+        ]
 
         # Add MCP-specific attributes
         if event.event_type:
@@ -232,6 +236,21 @@ class OTLPExporter(Exporter):
                 {
                     "key": "mcp.client_version",
                     "value": {"stringValue": event.client_version},
+                }
+            )
+
+        # Add customer-defined tags as individual attributes
+        for key, value in (getattr(event, "tags", None) or {}).items():
+            attributes.append(
+                {"key": f"mcpcat.tag.{key}", "value": {"stringValue": value}}
+            )
+
+        # Add customer-defined properties as JSON
+        if getattr(event, "properties", None):
+            attributes.append(
+                {
+                    "key": "mcpcat.properties",
+                    "value": {"stringValue": json.dumps(event.properties)},
                 }
             )
 

--- a/src/mcpcat/modules/exporters/sentry.py
+++ b/src/mcpcat/modules/exporters/sentry.py
@@ -7,6 +7,7 @@ from typing import Dict, Any, Optional, List
 import requests
 
 from ...types import Event, SentryExporterConfig
+from ...modules.constants import MCPCAT_SOURCE
 from ...modules.logging import write_to_log
 from . import Exporter
 from .trace_context import trace_context
@@ -345,14 +346,15 @@ class SentryExporter(Exporter):
             "timestamp": end_timestamp,
             "start_timestamp": start_timestamp,
             "transaction": transaction_name,
-            "contexts": {
-                "trace": {
+            "contexts": self.build_contexts(
+                event,
+                {
                     "trace_id": trace_id,
                     "span_id": span_id,
                     "op": event.event_type or "mcp.event",
                     "status": "internal_error" if event.is_error else "ok",
-                }
-            },
+                },
+            ),
             "tags": self.build_tags(event),
             "extra": self.build_extra(event),
         }
@@ -367,7 +369,9 @@ class SentryExporter(Exporter):
         Returns:
             Tags dictionary
         """
-        tags: Dict[str, str] = {}
+        tags: Dict[str, str] = {
+            "source": MCPCAT_SOURCE,
+        }
 
         if self.environment:
             tags["environment"] = self.environment
@@ -384,7 +388,21 @@ class SentryExporter(Exporter):
         if event.identify_actor_given_id:
             tags["actor_id"] = event.identify_actor_given_id
 
+        # Namespace customer tags to avoid collisions with Sentry reserved fields
+        if getattr(event, "tags", None):
+            for key, value in event.tags.items():
+                tags[f"mcpcat.{key}"] = value
+
         return tags
+
+    def build_contexts(
+        self, event: Event, trace_ctx: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Build Sentry contexts dict, embedding customer properties under `mcpcat`."""
+        contexts: Dict[str, Any] = {"trace": trace_ctx}
+        if getattr(event, "properties", None):
+            contexts["mcpcat"] = event.properties
+        return contexts
 
     def build_extra(self, event: Event) -> Dict[str, Any]:
         """
@@ -481,16 +499,19 @@ class SentryExporter(Exporter):
                 ]
             },
             "contexts": {
-                "trace": {
-                    "trace_id": trace_id,  # Same trace ID as transaction/log for correlation
-                    "span_id": span_id,
-                    "parent_span_id": transaction["contexts"]["trace"]["span_id"]
-                    if transaction
-                    else None,  # Link to transaction span if available
-                    "op": transaction["contexts"]["trace"]["op"]
-                    if transaction
-                    else (event.event_type or "mcp.event"),
-                },
+                **self.build_contexts(
+                    event,
+                    {
+                        "trace_id": trace_id,  # Same trace ID as transaction/log for correlation
+                        "span_id": span_id,
+                        "parent_span_id": transaction["contexts"]["trace"]["span_id"]
+                        if transaction
+                        else None,  # Link to transaction span if available
+                        "op": transaction["contexts"]["trace"]["op"]
+                        if transaction
+                        else (event.event_type or "mcp.event"),
+                    },
+                ),
                 "mcp": {
                     "resource_name": event.resource_name,
                     "session_id": event.session_id,

--- a/src/mcpcat/modules/internal.py
+++ b/src/mcpcat/modules/internal.py
@@ -1,5 +1,6 @@
 """Internal data storage for MCPCat."""
 
+import inspect
 import weakref
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
@@ -7,6 +8,7 @@ from typing import Any, Dict, List, Optional
 from ..types import EventType, MCPCatData, ToolRegistration, UnredactedEvent
 from .compatibility import is_official_fastmcp_server
 from .logging import write_to_log
+from .validation import validate_tags
 
 # WeakKeyDictionary to store data associated with server instances
 _server_data_map: weakref.WeakKeyDictionary[Any, MCPCatData] = (
@@ -116,6 +118,78 @@ def get_original_method(key: str) -> Optional[Any]:
 def get_original_methods() -> Dict[str, Any]:
     """Get the global original methods storage."""
     return _original_methods
+
+
+async def resolve_event_tags(
+    data: MCPCatData, request: Any, extra: Any
+) -> Optional[Dict[str, str]]:
+    """Resolve the event_tags callback and return validated tags.
+
+    Accepts sync or async callbacks. Returns None if no callback configured,
+    callback returns nullish, or callback raises.
+    """
+    callback = data.options.event_tags if data and data.options else None
+    if callback is None:
+        return None
+
+    try:
+        result = callback(request, extra)
+        if inspect.iscoroutine(result):
+            result = await result
+    except Exception as e:
+        write_to_log(f"event_tags callback error: {e}")
+        return None
+
+    if not result:
+        return None
+
+    return validate_tags(result)
+
+
+async def resolve_event_properties(
+    data: MCPCatData, request: Any, extra: Any
+) -> Optional[Dict[str, Any]]:
+    """Resolve the event_properties callback and return the result.
+
+    Accepts sync or async callbacks. Returns None if no callback configured,
+    callback returns nullish, or callback raises.
+    """
+    callback = data.options.event_properties if data and data.options else None
+    if callback is None:
+        return None
+
+    try:
+        result = callback(request, extra)
+        if inspect.iscoroutine(result):
+            result = await result
+    except Exception as e:
+        write_to_log(f"event_properties callback error: {e}")
+        return None
+
+    return result or None
+
+
+async def attach_event_metadata(
+    event: UnredactedEvent,
+    data: Optional[MCPCatData],
+    request: Any,
+    extra: Any,
+) -> None:
+    """Attach customer-defined tags and properties to an event before publish.
+
+    Safe no-op if data is None or callbacks are unset. Failures in either
+    callback are logged and swallowed — event is still published.
+    """
+    if data is None:
+        return
+
+    tags = await resolve_event_tags(data, request, extra)
+    if tags:
+        event.tags = tags
+
+    properties = await resolve_event_properties(data, request, extra)
+    if properties:
+        event.properties = properties
 
 
 def get_tool_timeline(server: Any) -> List[Dict[str, Any]]:

--- a/src/mcpcat/modules/overrides/community/monkey_patch.py
+++ b/src/mcpcat/modules/overrides/community/monkey_patch.py
@@ -14,7 +14,7 @@ from mcpcat.modules import event_queue
 from mcpcat.modules.compatibility import is_mcp_error_response
 from mcpcat.modules.exceptions import capture_exception
 from mcpcat.modules.identify import identify_session
-from mcpcat.modules.internal import get_server_tracking_data
+from mcpcat.modules.internal import attach_event_metadata, get_server_tracking_data
 from mcpcat.modules.logging import write_to_log
 from mcpcat.modules.session import (
     get_client_info_from_request_context,
@@ -128,6 +128,7 @@ def patch_community_fastmcp(server: Any) -> None:
                 client_name=client_name,
                 client_version=client_version,
             )
+            await attach_event_metadata(event, data, request, request_context)
 
             try:
                 # Handle get_more_tools specially - don't intercept for community FastMCP

--- a/src/mcpcat/modules/overrides/community_v3/middleware.py
+++ b/src/mcpcat/modules/overrides/community_v3/middleware.py
@@ -21,7 +21,7 @@ from mcpcat.modules.exceptions import (
     store_captured_error,
 )
 from mcpcat.modules.identify import identify_session
-from mcpcat.modules.internal import mark_tool_tracked, register_tool
+from mcpcat.modules.internal import attach_event_metadata, mark_tool_tracked, register_tool
 from mcpcat.modules.logging import write_to_log
 from mcpcat.modules.session import (
     get_client_info_from_request_context,
@@ -127,6 +127,7 @@ class MCPCatMiddleware:
             client_name=client_name,
             client_version=client_version,
         )
+        await attach_event_metadata(event, self.mcpcat_data, context.message, request_context)
 
         try:
             result = await call_next(context)
@@ -198,6 +199,7 @@ class MCPCatMiddleware:
             client_name=client_name,
             client_version=client_version,
         )
+        await attach_event_metadata(event, self.mcpcat_data, context.message, request_context)
 
         # Create modified context without context parameter if needed
         call_context = context
@@ -277,6 +279,7 @@ class MCPCatMiddleware:
             client_name=client_name,
             client_version=client_version,
         )
+        await attach_event_metadata(event, self.mcpcat_data, context.message, request_context)
 
         try:
             tools = list(await call_next(context))

--- a/src/mcpcat/modules/overrides/mcp_server.py
+++ b/src/mcpcat/modules/overrides/mcp_server.py
@@ -9,6 +9,7 @@ from mcp.shared.context import RequestContext
 from mcpcat.modules import event_queue
 from mcpcat.modules.compatibility import is_mcp_error_response
 from mcpcat.modules.identify import identify_session
+from mcpcat.modules.internal import attach_event_metadata
 from mcpcat.modules.logging import write_to_log
 from mcpcat.modules.tools import handle_report_missing
 
@@ -62,6 +63,7 @@ def override_lowlevel_mcp_server(server: Server, data: MCPCatData) -> None:
             client_name=client_name,
             client_version=client_version,
         )
+        await attach_event_metadata(event, data, request, request_context)
 
         # Call the original handler
         result = await original_initialize_handler(request)
@@ -91,6 +93,7 @@ def override_lowlevel_mcp_server(server: Server, data: MCPCatData) -> None:
             client_name=client_name,
             client_version=client_version,
         )
+        await attach_event_metadata(event, data, request, request_context)
 
         # Call the original handler to get the tools
         original_result = await original_list_tools_handler(request)
@@ -177,6 +180,7 @@ def override_lowlevel_mcp_server(server: Server, data: MCPCatData) -> None:
             client_name=client_name,
             client_version=client_version,
         )
+        await attach_event_metadata(event, data, request, request_context)
 
         # Extract user intent from context (but don't pop yet - we need it for the event)
         if data.options.enable_tool_call_context and tool_name != "get_more_tools":
@@ -267,6 +271,7 @@ def override_lowlevel_mcp_server_minimal(server: Server, data: MCPCatData) -> No
             client_name=client_name,
             client_version=client_version,
         )
+        await attach_event_metadata(event, data, request, request_context)
 
         # Call the original handler
         result = await original_initialize_handler(request)
@@ -296,6 +301,7 @@ def override_lowlevel_mcp_server_minimal(server: Server, data: MCPCatData) -> No
             client_name=client_name,
             client_version=client_version,
         )
+        await attach_event_metadata(event, data, request, request_context)
 
         # Call the original handler - tool modifications are handled by monkey-patch
         result = await original_list_tools_handler(request)

--- a/src/mcpcat/modules/overrides/official/monkey_patch.py
+++ b/src/mcpcat/modules/overrides/official/monkey_patch.py
@@ -20,6 +20,7 @@ from mcpcat.modules.exceptions import (
     store_captured_error,
 )
 from mcpcat.modules.internal import (
+    attach_event_metadata,
     get_original_method,
     get_server_tracking_data,
     is_tool_tracked,
@@ -237,6 +238,8 @@ def patch_fastmcp_tool_manager(server: Any, mcpcat_data: MCPCatData) -> bool:
                     current_data = mcpcat_data
 
                 # Handle session identification (non-critical)
+                request_context = None
+                mock_request = None
                 try:
                     request_context = safe_request_context(server._mcp_server)
                     client_name, client_version = (None, None)
@@ -301,6 +304,7 @@ def patch_fastmcp_tool_manager(server: Any, mcpcat_data: MCPCatData) -> bool:
                         client_name=client_name,
                         client_version=client_version,
                     )
+                    await attach_event_metadata(event, current_data, mock_request, request_context)
                 except Exception as e:
                     write_to_log(f"Error creating event: {e}")
                     event = None

--- a/src/mcpcat/modules/redaction.py
+++ b/src/mcpcat/modules/redaction.py
@@ -20,6 +20,8 @@ PROTECTED_FIELDS: Set[str] = {
     "resource_name",
     "event_type",
     "actor_id",
+    "tags",
+    "properties",
 }
 
 

--- a/src/mcpcat/modules/validation.py
+++ b/src/mcpcat/modules/validation.py
@@ -1,0 +1,68 @@
+"""Client-side validation for customer-defined event tags."""
+
+import re
+from typing import Optional
+
+from .logging import write_to_log
+
+TAG_KEY_REGEX = re.compile(r"^[a-zA-Z0-9$_.:\- ]+$")
+MAX_TAG_KEY_LENGTH = 32
+MAX_TAG_VALUE_LENGTH = 200
+MAX_TAG_ENTRIES = 50
+
+
+def validate_tags(tags: dict) -> Optional[dict]:
+    """Validate and filter a tags dict against MCPCat tag constraints.
+
+    Invalid entries are dropped with a warning logged via write_to_log.
+    Returns None if no valid entries remain.
+    """
+    if not tags:
+        return None
+
+    valid: list[tuple[str, str]] = []
+
+    for key, value in tags.items():
+        if not isinstance(key, str) or not key or not TAG_KEY_REGEX.match(key):
+            write_to_log(
+                f'Dropping invalid tag: "{key}" — key contains invalid characters or is empty'
+            )
+            continue
+
+        if len(key) > MAX_TAG_KEY_LENGTH:
+            write_to_log(
+                f'Dropping invalid tag: "{key}" — key exceeds max length of {MAX_TAG_KEY_LENGTH}'
+            )
+            continue
+
+        if not isinstance(value, str):
+            write_to_log(
+                f'Dropping invalid tag: "{key}" — non-string value (got {type(value).__name__})'
+            )
+            continue
+
+        if len(value) > MAX_TAG_VALUE_LENGTH:
+            write_to_log(
+                f'Dropping invalid tag: "{key}" — value exceeds max length of {MAX_TAG_VALUE_LENGTH}'
+            )
+            continue
+
+        if "\n" in value:
+            write_to_log(
+                f'Dropping invalid tag: "{key}" — value contains newline character'
+            )
+            continue
+
+        valid.append((key, value))
+
+    if not valid:
+        return None
+
+    if len(valid) > MAX_TAG_ENTRIES:
+        dropped = len(valid) - MAX_TAG_ENTRIES
+        write_to_log(
+            f"Dropping {dropped} tag(s) — exceeds maximum of {MAX_TAG_ENTRIES} entries per event"
+        )
+        valid = valid[:MAX_TAG_ENTRIES]
+
+    return dict(valid)

--- a/src/mcpcat/types.py
+++ b/src/mcpcat/types.py
@@ -14,6 +14,18 @@ from mcpcat.modules.constants import DEFAULT_CONTEXT_DESCRIPTION
 IdentifyFunction = Callable[[dict[str, Any], Any], Optional["UserIdentity"]]
 # Type alias for redaction function
 RedactionFunction = Callable[[str], str | Awaitable[str]]
+# Type alias for event_tags callback — returns str:str map attached to every auto-captured event.
+# Accepts sync or async callables (mirrors RedactionFunction).
+EventTagsFunction = Callable[
+    [Any, Any],
+    Optional[dict[str, str]] | Awaitable[Optional[dict[str, str]]],
+]
+# Type alias for event_properties callback — returns JSON-serializable map attached to every auto-captured event.
+# Accepts sync or async callables.
+EventPropertiesFunction = Callable[
+    [Any, Any],
+    Optional[dict[str, Any]] | Awaitable[Optional[dict[str, Any]]],
+]
 
 
 @dataclass
@@ -165,6 +177,23 @@ class MCPCatOptions:
     debug_mode: bool = False
     api_base_url: str | None = None
     stateless: bool | None = None
+    # Callback invoked on every auto-captured event (initialize, tools/list,
+    # tools/call) to attach string key-value tags. Tags are intended for
+    # structured metadata you'll filter or group by in the MCPCat dashboard
+    # (e.g. trace IDs, environments, regions). Validated client-side: keys
+    # must be <=32 chars matching [a-zA-Z0-9$_.:\- ], values must be strings
+    # <=200 chars without newlines, max 50 entries per event. Invalid entries
+    # are dropped with a warning logged to ~/mcpcat.log when debug_mode=True.
+    # May be sync or async. Receives the same (request, extra) arguments as
+    # `identify`. If the callback raises or returns None/{}, tags are omitted.
+    event_tags: EventTagsFunction | None = None
+    # Callback invoked on every auto-captured event to attach JSON-serializable
+    # metadata (device info, feature flags, nested context). No validation
+    # beyond standard JSON types — note: the event is serialized via
+    # model_dump_json() in the queue, so values must be JSON-serializable
+    # (stricter than the TypeScript SDK). May be sync or async. If the callback
+    # raises or returns None, properties are omitted.
+    event_properties: EventPropertiesFunction | None = None
 
 
 @dataclass

--- a/tests/test_event_tags_properties.py
+++ b/tests/test_event_tags_properties.py
@@ -1,0 +1,345 @@
+"""Integration and unit tests for event_tags and event_properties."""
+
+import json
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcpcat import MCPCatOptions, track
+from mcpcat.modules.constants import MCPCAT_SOURCE
+from mcpcat.modules.event_queue import EventQueue, set_event_queue
+from mcpcat.modules.internal import (
+    attach_event_metadata,
+    resolve_event_properties,
+    resolve_event_tags,
+)
+from mcpcat.modules.redaction import redact_event
+from mcpcat.types import EventType, MCPCatData, SessionInfo, UnredactedEvent
+
+from .test_utils.client import create_test_client
+from .test_utils.todo_server import create_todo_server
+
+
+def _make_data(event_tags=None, event_properties=None) -> MCPCatData:
+    return MCPCatData(
+        project_id="p",
+        session_id="ses_x",
+        last_activity=None,
+        session_info=SessionInfo(),
+        identified_sessions={},
+        options=MCPCatOptions(
+            event_tags=event_tags, event_properties=event_properties
+        ),
+    )
+
+
+class TestResolvers:
+    async def test_no_callback_returns_none(self):
+        data = _make_data()
+        assert await resolve_event_tags(data, None, None) is None
+        assert await resolve_event_properties(data, None, None) is None
+
+    async def test_tags_callback_result_is_validated(self):
+        data = _make_data(event_tags=lambda r, e: {"env": "prod", "bad!": "x"})
+        assert await resolve_event_tags(data, None, None) == {"env": "prod"}
+
+    async def test_tags_callback_none_returns_none(self):
+        data = _make_data(event_tags=lambda r, e: None)
+        assert await resolve_event_tags(data, None, None) is None
+
+    async def test_tags_callback_empty_returns_none(self):
+        data = _make_data(event_tags=lambda r, e: {})
+        assert await resolve_event_tags(data, None, None) is None
+
+    async def test_tags_callback_exception_swallowed(self):
+        def boom(r, e):
+            raise RuntimeError("nope")
+
+        data = _make_data(event_tags=boom)
+        assert await resolve_event_tags(data, None, None) is None
+
+    async def test_properties_callback_result_passed_through(self):
+        data = _make_data(event_properties=lambda r, e: {"x": 1, "y": [1, 2]})
+        assert await resolve_event_properties(data, None, None) == {
+            "x": 1,
+            "y": [1, 2],
+        }
+
+    async def test_properties_callback_exception_swallowed(self):
+        def boom(r, e):
+            raise ValueError("bad")
+
+        data = _make_data(event_properties=boom)
+        assert await resolve_event_properties(data, None, None) is None
+
+    async def test_async_tags_callback_awaited(self):
+        async def async_cb(r, e):
+            return {"env": "prod", "bad!": "x"}
+
+        data = _make_data(event_tags=async_cb)
+        assert await resolve_event_tags(data, None, None) == {"env": "prod"}
+
+    async def test_async_properties_callback_awaited(self):
+        async def async_cb(r, e):
+            return {"x": 1, "nested": {"y": 2}}
+
+        data = _make_data(event_properties=async_cb)
+        assert await resolve_event_properties(data, None, None) == {
+            "x": 1,
+            "nested": {"y": 2},
+        }
+
+    async def test_async_tags_callback_exception_swallowed(self):
+        async def boom(r, e):
+            raise RuntimeError("async nope")
+
+        data = _make_data(event_tags=boom)
+        assert await resolve_event_tags(data, None, None) is None
+
+    async def test_callbacks_receive_request_and_extra(self):
+        seen: list = []
+
+        def cb(r, e):
+            seen.append((r, e))
+            return {"k": "v"}
+
+        data = _make_data(event_tags=cb)
+        await resolve_event_tags(data, "req-obj", "extra-obj")
+        assert seen == [("req-obj", "extra-obj")]
+
+
+class TestAttachMetadata:
+    def _event(self):
+        return UnredactedEvent(
+            session_id="s",
+            event_type=EventType.MCP_TOOLS_CALL.value,
+        )
+
+    async def test_no_data_is_noop(self):
+        event = self._event()
+        await attach_event_metadata(event, None, None, None)
+        assert getattr(event, "tags", None) is None
+        assert getattr(event, "properties", None) is None
+
+    async def test_attaches_tags_and_properties(self):
+        data = _make_data(
+            event_tags=lambda r, e: {"env": "prod"},
+            event_properties=lambda r, e: {"flag": True},
+        )
+        event = self._event()
+        await attach_event_metadata(event, data, None, None)
+        assert event.tags == {"env": "prod"}
+        assert event.properties == {"flag": True}
+
+    async def test_attaches_from_async_callbacks(self):
+        async def tags_cb(r, e):
+            return {"env": "prod"}
+
+        async def props_cb(r, e):
+            return {"flag": True}
+
+        data = _make_data(event_tags=tags_cb, event_properties=props_cb)
+        event = self._event()
+        await attach_event_metadata(event, data, None, None)
+        assert event.tags == {"env": "prod"}
+        assert event.properties == {"flag": True}
+
+    async def test_only_assigns_non_none(self):
+        data = _make_data(event_tags=lambda r, e: None)
+        event = self._event()
+        await attach_event_metadata(event, data, None, None)
+        assert getattr(event, "tags", None) is None
+
+    async def test_callback_failure_does_not_block_event(self):
+        def raises(r, e):
+            raise RuntimeError("nope")
+
+        data = _make_data(event_tags=raises, event_properties=lambda r, e: {"a": 1})
+        event = self._event()
+        await attach_event_metadata(event, data, None, None)
+        assert getattr(event, "tags", None) is None
+        assert event.properties == {"a": 1}
+
+
+class TestRedactionExemption:
+    def test_tags_and_properties_not_redacted(self):
+        event = {
+            "session_id": "s",
+            "tags": {"env": "production", "trace": "abc"},
+            "properties": {"secret_looking": "ssn-123-45-6789"},
+            "parameters": {"q": "redact me"},
+        }
+        result = redact_event(event, lambda s: "[REDACTED]")
+        assert result["tags"] == {"env": "production", "trace": "abc"}
+        assert result["properties"] == {"secret_looking": "ssn-123-45-6789"}
+        assert result["parameters"]["q"] == "[REDACTED]"
+
+
+class TestFastMCPIntegration:
+    """End-to-end test against the FastMCP test server."""
+
+    @pytest.fixture(autouse=True)
+    def restore_queue(self):
+        from mcpcat.modules.event_queue import event_queue as original
+        yield
+        set_event_queue(original)
+
+    @pytest.mark.asyncio
+    async def test_callbacks_flow_through_to_published_event(self):
+        captured = []
+        mock_api = MagicMock()
+        mock_api.publish_event = MagicMock(side_effect=lambda publish_event_request: captured.append(publish_event_request))
+        set_event_queue(EventQueue(api_client=mock_api))
+
+        server = create_todo_server()
+        track(
+            server,
+            "proj_test",
+            MCPCatOptions(
+                event_tags=lambda req, ctx: {"env": "test", "bad!": "dropped"},
+                event_properties=lambda req, ctx: {"flag": True, "build": "abc"},
+            ),
+        )
+
+        async with create_test_client(server) as client:
+            await client.call_tool("add_todo", {"text": "hi"})
+            time.sleep(0.5)
+
+        tool_events = [e for e in captured if e.event_type == EventType.MCP_TOOLS_CALL.value]
+        assert tool_events, "no tool call event captured"
+        event = tool_events[0]
+        assert event.tags == {"env": "test"}  # bad! dropped by validation
+        assert event.properties == {"flag": True, "build": "abc"}
+
+    @pytest.mark.asyncio
+    async def test_callback_exception_does_not_break_publish(self):
+        captured = []
+        mock_api = MagicMock()
+        mock_api.publish_event = MagicMock(side_effect=lambda publish_event_request: captured.append(publish_event_request))
+        set_event_queue(EventQueue(api_client=mock_api))
+
+        def boom(req, ctx):
+            raise RuntimeError("callback broken")
+
+        server = create_todo_server()
+        track(server, "proj_test", MCPCatOptions(event_tags=boom, event_properties=boom))
+
+        async with create_test_client(server) as client:
+            await client.call_tool("add_todo", {"text": "hi"})
+            time.sleep(0.5)
+
+        tool_events = [e for e in captured if e.event_type == EventType.MCP_TOOLS_CALL.value]
+        assert tool_events
+        assert tool_events[0].tags is None
+        assert tool_events[0].properties is None
+
+    @pytest.mark.asyncio
+    async def test_async_callbacks_flow_through_to_published_event(self):
+        captured = []
+        mock_api = MagicMock()
+        mock_api.publish_event = MagicMock(side_effect=lambda publish_event_request: captured.append(publish_event_request))
+        set_event_queue(EventQueue(api_client=mock_api))
+
+        async def async_tags(req, ctx):
+            return {"env": "test", "bad!": "dropped"}
+
+        async def async_props(req, ctx):
+            return {"flag": True, "nested": {"x": 1}}
+
+        server = create_todo_server()
+        track(
+            server,
+            "proj_test",
+            MCPCatOptions(event_tags=async_tags, event_properties=async_props),
+        )
+
+        async with create_test_client(server) as client:
+            await client.call_tool("add_todo", {"text": "hi"})
+            time.sleep(0.5)
+
+        tool_events = [e for e in captured if e.event_type == EventType.MCP_TOOLS_CALL.value]
+        assert tool_events, "no tool call event captured"
+        event = tool_events[0]
+        assert event.tags == {"env": "test"}
+        assert event.properties == {"flag": True, "nested": {"x": 1}}
+
+
+class TestDatadogExporter:
+    def _event(self, **kwargs):
+        event = UnredactedEvent(
+            session_id="s1",
+            event_type=EventType.MCP_TOOLS_CALL.value,
+            resource_name="my_tool",
+        )
+        for k, v in kwargs.items():
+            setattr(event, k, v)
+        return event
+
+    def test_source_and_customer_tags_added_to_ddtags(self):
+        from mcpcat.modules.exporters.datadog import DatadogExporter
+
+        exporter = DatadogExporter(
+            {"type": "datadog", "api_key": "k", "site": "datadoghq.com", "service": "svc", "env": "prod"}
+        )
+        event = self._event(
+            tags={"Trace:Id": "abc,def", "Region": "us-east-1"},
+            properties={"flag": True},
+        )
+        log = exporter.event_to_log(event)
+        ddtags = log["ddtags"].split(",")
+        assert f"source:{MCPCAT_SOURCE}" in ddtags
+        assert "mcpcat.trace_id:abc_def" in ddtags  # key sanitized + value comma→_
+        assert "mcpcat.region:us-east-1" in ddtags
+        assert log["ddsource"] == MCPCAT_SOURCE
+        assert log["mcp"]["tags"] == {"Trace:Id": "abc,def", "Region": "us-east-1"}
+        assert log["mcp"]["properties"] == {"flag": True}
+
+
+class TestOTLPExporter:
+    def test_source_and_customer_tags_and_properties(self):
+        from mcpcat.modules.exporters.otlp import OTLPExporter
+
+        exporter = OTLPExporter({"type": "otlp"})
+        event = UnredactedEvent(
+            session_id="s1",
+            event_type=EventType.MCP_TOOLS_CALL.value,
+        )
+        event.tags = {"env": "prod"}
+        event.properties = {"flag": True, "count": 3}
+        attrs = exporter._get_span_attributes(event)
+        keys = {a["key"]: a["value"].get("stringValue") for a in attrs}
+        assert keys.get("source") == MCPCAT_SOURCE
+        assert keys.get("mcpcat.tag.env") == "prod"
+        assert json.loads(keys["mcpcat.properties"]) == {"flag": True, "count": 3}
+
+
+class TestSentryExporter:
+    def test_source_and_customer_tags_namespaced_and_properties_in_context(self):
+        from mcpcat.modules.exporters.sentry import SentryExporter
+
+        exporter = SentryExporter(
+            {
+                "type": "sentry",
+                "dsn": "https://abc123@sentry.example.com/42",
+                "environment": "prod",
+                "enable_tracing": True,
+            }
+        )
+        event = UnredactedEvent(
+            session_id="s1",
+            event_type=EventType.MCP_TOOLS_CALL.value,
+            resource_name="my_tool",
+            duration=100,
+        )
+        event.tags = {"env": "test", "trace_id": "abc"}
+        event.properties = {"flag": True, "nested": {"x": 1}}
+
+        tags = exporter.build_tags(event)
+        assert tags["source"] == MCPCAT_SOURCE
+        assert tags["mcpcat.env"] == "test"
+        assert tags["mcpcat.trace_id"] == "abc"
+
+        contexts = exporter.build_contexts(event, {"trace_id": "t"})
+        assert contexts["trace"] == {"trace_id": "t"}
+        assert contexts["mcpcat"] == {"flag": True, "nested": {"x": 1}}

--- a/tests/test_tag_validation.py
+++ b/tests/test_tag_validation.py
@@ -1,0 +1,80 @@
+"""Tests for tag validation."""
+
+from unittest.mock import patch
+
+import pytest
+
+from mcpcat.modules.validation import (
+    MAX_TAG_ENTRIES,
+    MAX_TAG_KEY_LENGTH,
+    MAX_TAG_VALUE_LENGTH,
+    validate_tags,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_log():
+    with patch("mcpcat.modules.validation.write_to_log") as mock:
+        yield mock
+
+
+class TestValidateTags:
+    def test_passes_through_valid_tags_unchanged(self):
+        tags = {"env": "production", "trace_id": "abc-123", "region": "us-east-1"}
+        assert validate_tags(tags) == tags
+
+    def test_returns_none_for_empty_dict(self):
+        assert validate_tags({}) is None
+
+    def test_drops_keys_with_invalid_characters(self, mock_log):
+        tags = {"valid_key": "value", "invalid!key": "value", "good.key": "value"}
+        assert validate_tags(tags) == {"valid_key": "value", "good.key": "value"}
+        assert any("invalid!key" in call.args[0] for call in mock_log.call_args_list)
+
+    def test_drops_keys_longer_than_max(self, mock_log):
+        long_key = "a" * (MAX_TAG_KEY_LENGTH + 1)
+        tags = {long_key: "value", "short": "value"}
+        assert validate_tags(tags) == {"short": "value"}
+        assert any("exceeds max length" in call.args[0] for call in mock_log.call_args_list)
+
+    def test_drops_values_longer_than_max(self, mock_log):
+        long_value = "a" * (MAX_TAG_VALUE_LENGTH + 1)
+        tags = {"key1": long_value, "key2": "short"}
+        assert validate_tags(tags) == {"key2": "short"}
+        assert any("exceeds max length" in call.args[0] for call in mock_log.call_args_list)
+
+    def test_drops_values_containing_newlines(self, mock_log):
+        tags = {"key1": "has\nnewline", "key2": "clean"}
+        assert validate_tags(tags) == {"key2": "clean"}
+        assert any("newline" in call.args[0] for call in mock_log.call_args_list)
+
+    def test_drops_non_string_values(self, mock_log):
+        tags = {"key1": 123, "key2": "valid"}
+        assert validate_tags(tags) == {"key2": "valid"}
+        assert any("non-string" in call.args[0] for call in mock_log.call_args_list)
+
+    def test_drops_empty_string_keys(self):
+        tags = {"": "empty-key-value", "valid": "value"}
+        assert validate_tags(tags) == {"valid": "value"}
+
+    def test_keeps_only_first_50_entries_when_exceeding_limit(self, mock_log):
+        tags = {f"key{i:03d}": f"value{i}" for i in range(60)}
+        result = validate_tags(tags)
+        assert result is not None
+        assert len(result) == MAX_TAG_ENTRIES
+        assert any("Dropping 10" in call.args[0] for call in mock_log.call_args_list)
+
+    def test_returns_none_when_all_entries_invalid(self):
+        tags = {"!!!": "value", "###": "value"}
+        assert validate_tags(tags) is None
+
+    def test_allows_special_chars_in_keys(self):
+        tags = {
+            "my.tag": "value",
+            "my:tag": "value",
+            "my-tag": "value",
+            "my tag": "value",
+            "$ai_trace_id": "trace-1",
+            "my$key": "value",
+        }
+        assert validate_tags(tags) == tags


### PR DESCRIPTION
## What

Two new callbacks on `MCPCatOptions` — `event_tags` and `event_properties` — that let customers attach custom metadata to every auto-captured event (initialize, tools/list, tools/call). Ports the equivalent feature from the TypeScript SDK (PR #32 there).

- `event_tags`: `dict[str, str]`, validated client-side (regex on keys, length caps, max 50 entries, no newlines in values). Invalid entries are dropped with a warning.
- `event_properties`: `dict[str, Any]`, arbitrary JSON-serializable metadata, no validation.
- Both bypass redaction/sanitization/truncation — customer-supplied, passed through as-is.
- Both accept sync or async callables.

## Why

Customers want to filter/group events by structured metadata they control — trace IDs, environments, deployment regions, feature flags. Until now there's no way to attach that kind of data through the SDK.

## Exporter changes worth flagging

- Every outbound event now carries `source=mcpcat` (new `MCPCAT_SOURCE` constant). Makes MCPcat events distinguishable from other telemetry flowing into the customer's observability backend.
- Customer tags are namespaced — `mcpcat.<key>` in Datadog ddtags and Sentry tags, `mcpcat.tag.<key>` as OTLP span attributes. Prevents collisions with reserved tag keys (`environment`, `release`, `host`, `service`, etc.).
- Sentry properties moved from the deprecated `extra` field into `contexts.mcpcat`.

## Test plan

- [ ] `uv run python -m pytest tests/test_event_tags_properties.py tests/test_tag_validation.py -v` — 34 tests pass
- [ ] `uv run python -m pytest` — full regression green
- [ ] Manually verified end-to-end against local BE: SDK sends events with tags/properties → SQS → process_events → event detail API returns them. Confirmed for both sync and async callback paths. Covered in the separate BE change that exposes tags/properties on `EventSerializer`.

## Notes

- Async callback support uses the same sync-or-async pattern as `RedactionFunction`. If the callback returns a coroutine, the resolver awaits it; otherwise passes through.
- Validation rules match the TS SDK and the backend's `validate_tags` exactly, so client- and server-side drop behavior is consistent.
- `identify` remains sync-only for now — making it async-compatible is a separate (small) change.