### PR TITLE
feat: run identify hook per event and drop session identity cache

### DIFF
--- a/src/mcpcat/__init__.py
+++ b/src/mcpcat/__init__.py
@@ -113,7 +113,6 @@ def track(
         project_id=project_id,
         last_activity=datetime.now(timezone.utc),
         session_info=session_info,
-        identified_sessions={},
         options=options,
         is_stateless=options.stateless if options.stateless is not None else _detect_stateless(server),
     )

--- a/src/mcpcat/modules/identify.py
+++ b/src/mcpcat/modules/identify.py
@@ -1,67 +1,30 @@
 from datetime import datetime, timezone
 
 from mcpcat.modules import event_queue
-from mcpcat.modules.internal import get_server_tracking_data, set_server_tracking_data
+from mcpcat.modules.internal import get_server_tracking_data
 from mcpcat.modules.logging import write_to_log
 from mcpcat.types import EventType, UnredactedEvent, UserIdentity
 
 
 def identify_session(server, request: any, context: any) -> UserIdentity | None:
-    """
-    Identify the user based on the request and context.
+    """Run the configured identify hook and publish a `mcpcat:identify` event.
 
-    Calls the user-defined identify function with the full request and context objects.
-    The context may contain transport-specific information (e.g., HTTP headers for SSE/WebSocket transports).
-
-    :param server: The MCP server instance.
-    :param request: The request data containing user information.
-    :param context: The full context object which may include transport-specific data.
-    :return: An instance of UserIdentity or None if identification fails.
+    Returns the resulting UserIdentity, or None if no hook is configured, the
+    hook raises, or it returns a non-UserIdentity value.
     """
     data = get_server_tracking_data(server)
 
     if not data or not data.options or not data.options.identify:
-        return
+        return None
 
-    # Stateless mode: run identify on every request, return identity directly
-    if data.is_stateless:
-        try:
-            identify_result = data.options.identify(request, context)
-            if not identify_result or not isinstance(identify_result, UserIdentity):
-                write_to_log(
-                    f"User identification function did not return a valid UserIdentity instance. Received: {identify_result}"
-                )
-                return
-            return identify_result
-        except Exception as e:
-            write_to_log(f"Error occurred during user identification: {e}")
-            return
-
-    # Stateful mode: existing behavior unchanged
-    if context is None:
-        write_to_log("Context is None, skipping user identification")
-        return
-
-    if data.identified_sessions.get(data.session_id):
-        write_to_log(
-            f"User is already identified: {data.identified_sessions[data.session_id].user_id}"
-        )
-        return
-
-    # Call the user-defined identify function
     try:
         identify_result = data.options.identify(request, context)
         if not identify_result or not isinstance(identify_result, UserIdentity):
             write_to_log(
                 f"User identification function did not return a valid UserIdentity instance. Received: {identify_result}"
             )
-            return
+            return None
 
-        data.identified_sessions[data.session_id] = identify_result
-        write_to_log(
-            f"User identified: {identify_result.user_id} - {identify_result.user_name or 'Unknown Name'}"
-        )
-        set_server_tracking_data(server, data)
         event = UnredactedEvent(
             session_id=data.session_id,
             timestamp=datetime.now(timezone.utc),
@@ -71,8 +34,8 @@ def identify_session(server, request: any, context: any) -> UserIdentity | None:
             identify_data=identify_result.user_data or {},
         )
         event_queue.publish_event(server, event)
+
+        return identify_result
     except Exception as e:
         write_to_log(f"Error occurred during user identification: {e}")
-        return
-
-    return identify_result
+        return None

--- a/src/mcpcat/modules/session.py
+++ b/src/mcpcat/modules/session.py
@@ -3,7 +3,6 @@
 import re
 import sys
 from datetime import datetime, timedelta, timezone
-from typing import Optional
 
 from mcp.shared.context import RequestContext
 from mcp.server import Server
@@ -12,7 +11,7 @@ from mcpcat.modules.constants import INACTIVITY_TIMEOUT_IN_MINUTES, SESSION_ID_P
 from mcpcat.modules.internal import get_server_tracking_data, set_server_tracking_data
 from mcpcat.modules.logging import write_to_log
 
-from ..types import MCPCatData, SessionInfo, UserIdentity
+from ..types import MCPCatData, SessionInfo
 from ..utils import generate_prefixed_ksuid
 
 
@@ -146,10 +145,6 @@ def get_client_info_from_request_context(
 
 def get_session_info(server: Server, data: MCPCatData | None = None) -> SessionInfo:
     """Get session information for the current MCP session."""
-    actor_info: Optional[UserIdentity] = None
-    if data and not data.is_stateless:
-        actor_info = data.identified_sessions.get(data.session_id, None)
-
     session_info = SessionInfo(
         ip_address=None,  # grab from django
         sdk_language=f"Python {sys.version_info.major}.{sys.version_info.minor}",
@@ -162,9 +157,9 @@ def get_session_info(server: Server, data: MCPCatData | None = None) -> SessionI
         client_version=data.session_info.client_version
         if data and data.session_info and not data.is_stateless
         else None,
-        identify_actor_given_id=actor_info.user_id if actor_info else None,
-        identify_actor_name=actor_info.user_name if actor_info else None,
-        identify_data=actor_info.user_data if actor_info else None,
+        identify_actor_given_id=None,
+        identify_actor_name=None,
+        identify_data=None,
     )
 
     if not data:

--- a/src/mcpcat/types.py
+++ b/src/mcpcat/types.py
@@ -175,7 +175,6 @@ class MCPCatData:
     session_id: str
     session_info: SessionInfo
     last_activity: datetime
-    identified_sessions: dict[str, UserIdentity]
     options: MCPCatOptions
 
     # Dynamic tracking fields (initialized on demand)

--- a/tests/community/test_community_event_capture.py
+++ b/tests/community/test_community_event_capture.py
@@ -174,47 +174,33 @@ class TestCommunityEventCapture:
         test_queue = EventQueue(api_client=mock_api_client)
         set_event_queue(test_queue)
 
-        server = create_community_todo_server()
-        options = MCPCatOptions(enable_tracing=True)
-        track(server, "test_project", options)
-
-        async with create_community_test_client(server) as client:
-            # First call - no actor info
-            await client.call_tool("add_todo", {"text": "Test 1"})
-            time.sleep(0.5)
-
-            # Manually identify the user by setting session data
-            lowlevel_server = get_lowlevel_server(server)
-            data = get_server_tracking_data(lowlevel_server)
-            user_identity = UserIdentity(
+        def identify_fn(request, context):
+            return UserIdentity(
                 user_id="user123",
                 user_name="John Doe",
                 user_data={"email": "john@example.com", "role": "admin"},
             )
-            data.identified_sessions[data.session_id] = user_identity
-            set_server_tracking_data(lowlevel_server, data)
 
-            # Second call - should have actor info
+        server = create_community_todo_server()
+        options = MCPCatOptions(enable_tracing=True, identify=identify_fn)
+        track(server, "test_project", options)
+
+        async with create_community_test_client(server) as client:
+            await client.call_tool("add_todo", {"text": "Test 1"})
+            time.sleep(0.5)
             await client.call_tool("add_todo", {"text": "Test 2"})
             time.sleep(1.0)
 
         tool_events = [e for e in captured_events if e.event_type == "mcp:tools/call"]
         assert len(tool_events) >= 2
 
-        # First event should not have actor info
-        first_event = tool_events[0]
-        assert first_event.identify_actor_given_id is None
-        assert first_event.identify_actor_name is None
-        assert first_event.identify_data is None
-
-        # Second event should have actor info
-        second_event = tool_events[1]
-        assert second_event.identify_actor_given_id == "user123"
-        assert second_event.identify_actor_name == "John Doe"
-        assert second_event.identify_data == {
-            "email": "john@example.com",
-            "role": "admin",
-        }
+        for event in tool_events[:2]:
+            assert event.identify_actor_given_id == "user123"
+            assert event.identify_actor_name == "John Doe"
+            assert event.identify_data == {
+                "email": "john@example.com",
+                "role": "admin",
+            }
 
     @pytest.mark.asyncio
     async def test_multiple_event_types_capture_all_fields(self):

--- a/tests/test_event_capture_completeness.py
+++ b/tests/test_event_capture_completeness.py
@@ -222,7 +222,7 @@ class TestEventCaptureCompleteness:
 
     @pytest.mark.asyncio
     async def test_event_contains_actor_info_after_identify(self):
-        """Test that events contain actor information after identify is called."""
+        """Events carry identity fields when an identify hook is configured."""
         mock_api_client = MagicMock()
         captured_events = []
 
@@ -234,46 +234,33 @@ class TestEventCaptureCompleteness:
         test_queue = EventQueue(api_client=mock_api_client)
         set_event_queue(test_queue)
 
-        server = create_todo_server()
-        options = MCPCatOptions(enable_tracing=True)
-        track(server, "test_project", options)
-
-        async with create_test_client(server) as client:
-            # First call - no actor info
-            await client.call_tool("add_todo", {"text": "Test 1"})
-            time.sleep(0.5)
-
-            # Manually identify the user by setting session data
-            data = get_server_tracking_data(server)
-            user_identity = UserIdentity(
+        def identify_fn(request, context):
+            return UserIdentity(
                 user_id="user123",
                 user_name="John Doe",
                 user_data={"email": "john@example.com", "role": "admin"},
             )
-            data.identified_sessions[data.session_id] = user_identity
-            set_server_tracking_data(server, data)
 
-            # Second call - should have actor info
+        server = create_todo_server()
+        options = MCPCatOptions(enable_tracing=True, identify=identify_fn)
+        track(server, "test_project", options)
+
+        async with create_test_client(server) as client:
+            await client.call_tool("add_todo", {"text": "Test 1"})
+            time.sleep(0.5)
             await client.call_tool("add_todo", {"text": "Test 2"})
             time.sleep(1.0)
 
         tool_events = [e for e in captured_events if e.event_type == "mcp:tools/call"]
         assert len(tool_events) >= 2
 
-        # First event should not have actor info
-        first_event = tool_events[0]
-        assert first_event.identify_actor_given_id is None
-        assert first_event.identify_actor_name is None
-        assert first_event.identify_data is None
-
-        # Second event should have actor info
-        second_event = tool_events[1]
-        assert second_event.identify_actor_given_id == "user123"
-        assert second_event.identify_actor_name == "John Doe"
-        assert second_event.identify_data == {
-            "email": "john@example.com",
-            "role": "admin",
-        }
+        for event in tool_events[:2]:
+            assert event.identify_actor_given_id == "user123"
+            assert event.identify_actor_name == "John Doe"
+            assert event.identify_data == {
+                "email": "john@example.com",
+                "role": "admin",
+            }
 
     @pytest.mark.asyncio
     async def test_multiple_event_types_capture_all_fields(self):

--- a/tests/test_event_queue.py
+++ b/tests/test_event_queue.py
@@ -546,7 +546,6 @@ class TestPublishEvent:
             session_id="session-123",
             session_info=SessionInfo(),
             last_activity=datetime.now(timezone.utc),
-            identified_sessions={},
             options=MCPCatOptions(redact_sensitive_information=None),
         )
         mock_tracking.return_value = mock_data
@@ -612,7 +611,6 @@ class TestPublishEvent:
             session_id="session-123",
             session_info=SessionInfo(),
             last_activity=datetime.now(timezone.utc),
-            identified_sessions={},
             options=MCPCatOptions(),
         )
         mock_tracking.return_value = mock_data
@@ -652,7 +650,6 @@ class TestPublishEvent:
             session_id="session-123",
             session_info=SessionInfo(),
             last_activity=datetime.now(timezone.utc),
-            identified_sessions={},
             options=MCPCatOptions(),
         )
         mock_tracking.return_value = mock_data
@@ -681,7 +678,6 @@ class TestPublishEvent:
             session_id="session-123",
             session_info=SessionInfo(),
             last_activity=datetime.now(timezone.utc),
-            identified_sessions={},
             options=MCPCatOptions(redact_sensitive_information=mock_redaction_fn),
         )
         mock_tracking.return_value = mock_data

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -16,7 +16,7 @@ from mcpcat.modules.session import (
     new_session_id,
     set_last_activity,
 )
-from mcpcat.types import MCPCatData, MCPCatOptions, SessionInfo, UserIdentity
+from mcpcat.types import MCPCatData, MCPCatOptions, SessionInfo
 
 from .test_utils.todo_server import create_todo_server
 
@@ -95,7 +95,6 @@ class TestGetSessionInfo:
             session_id="test_session",
             session_info=SessionInfo(client_name="TestClient", client_version="2.0.0"),
             last_activity=datetime.now(timezone.utc),
-            identified_sessions={},
             options=MCPCatOptions(),
         )
 
@@ -110,31 +109,21 @@ class TestGetSessionInfo:
         # Verify that the session_info was updated in the data object
         assert data.session_info == session_info
 
-    def test_with_identified_actor(self):
-        """Test get_session_info with an identified actor."""
-        user_identity = UserIdentity(
-            user_id="user123",
-            user_name="John Doe",
-            user_data={"role": "admin", "department": "engineering"},
-        )
-
+    def test_session_info_never_carries_identity(self):
+        """get_session_info returns None for identity fields."""
         data = MCPCatData(
             project_id="test_project",
             session_id="test_session",
             session_info=SessionInfo(client_name="TestClient", client_version="2.0.0"),
             last_activity=datetime.now(timezone.utc),
-            identified_sessions={"test_session": user_identity},
             options=MCPCatOptions(),
         )
 
         session_info = get_session_info(self.server, data)
 
-        assert session_info.identify_actor_given_id == "user123"
-        assert session_info.identify_actor_name == "John Doe"
-        assert session_info.identify_data == {
-            "role": "admin",
-            "department": "engineering",
-        }
+        assert session_info.identify_actor_given_id is None
+        assert session_info.identify_actor_name is None
+        assert session_info.identify_data is None
 
     def test_server_without_name_or_version(self):
         """Test get_session_info with a server that doesn't have name or version attributes."""
@@ -158,7 +147,6 @@ class TestGetSessionInfo:
                 client_name="TrackedClient", client_version="3.0.0"
             ),
             last_activity=datetime.now(timezone.utc),
-            identified_sessions={},
             options=MCPCatOptions(),
         )
 
@@ -194,7 +182,6 @@ class TestSetLastActivity:
             session_id="test_session",
             session_info=SessionInfo(),
             last_activity=initial_time,
-            identified_sessions={},
             options=MCPCatOptions(),
         )
 
@@ -230,7 +217,6 @@ class TestGetServerSessionId:
             session_id=self.initial_session_id,
             session_info=SessionInfo(),
             last_activity=self.initial_time,
-            identified_sessions={},
             options=MCPCatOptions(),
         )
 
@@ -346,7 +332,6 @@ class TestIntegration:
                 client_name="IntegrationClient", client_version="1.0.0"
             ),
             last_activity=datetime.now(timezone.utc),
-            identified_sessions={},
             options=MCPCatOptions(),
         )
 
@@ -361,37 +346,14 @@ class TestIntegration:
         assert session_info.server_name == "todo-server"
         assert session_info.client_name == "IntegrationClient"
 
-        # Simulate user identification
-        user_identity = UserIdentity(
-            user_id="integration_user",
-            user_name="Integration User",
-            user_data={"test": "data"},
-        )
-        data.identified_sessions[initial_session_id] = user_identity
-
-        # Get session info with identified user
-        # Create new data object since session_info was converted to dict
-        data_with_user = MCPCatData(
-            project_id="integration_project",
-            session_id=initial_session_id,
-            session_info=SessionInfo(
-                client_name="IntegrationClient", client_version="1.0.0"
-            ),
-            last_activity=datetime.now(timezone.utc),
-            identified_sessions={initial_session_id: user_identity},
-            options=MCPCatOptions(),
-        )
-        session_info = get_session_info(server, data_with_user)
-        assert session_info.identify_actor_given_id == "integration_user"
-        assert session_info.identify_actor_name == "Integration User"
+        assert session_info.identify_actor_given_id is None
+        assert session_info.identify_actor_name is None
 
         # Test session timeout and renewal
         with freeze_time("2024-01-01 12:31:00"):  # 31 minutes later
             new_sid = get_server_session_id(server)
             assert new_sid != initial_session_id
 
-            # Old session's user identity should not apply to new session
-            # Create new data for testing since stored data has dict session_info
             new_data = MCPCatData(
                 project_id="integration_project",
                 session_id=new_sid,
@@ -399,7 +361,6 @@ class TestIntegration:
                     client_name="IntegrationClient", client_version="1.0.0"
                 ),
                 last_activity=datetime(2024, 1, 1, 12, 31, 0),
-                identified_sessions={},  # No user identified for new session
                 options=MCPCatOptions(),
             )
             session_info = get_session_info(server, new_data)
@@ -416,7 +377,6 @@ class TestIntegration:
             session_id=new_session_id(),
             session_info=SessionInfo(),
             last_activity=datetime.now(timezone.utc),
-            identified_sessions={},
             options=MCPCatOptions(),
         )
 
@@ -437,17 +397,9 @@ class TestIntegration:
         assert data.last_activity > original_activity
 
     def test_session_info_updates_tracked_data(self):
-        """Test that get_session_info properly updates tracked server data."""
+        """get_session_info updates the tracked data's session_info."""
         server = create_todo_server()
 
-        # Create user identity
-        user_identity = UserIdentity(
-            user_id="tracked_user",
-            user_name="Tracked User",
-            user_data={"tracked": "yes"},
-        )
-
-        # Initialize data with identified session
         data = MCPCatData(
             project_id="update_test",
             session_id="update_session",
@@ -455,20 +407,16 @@ class TestIntegration:
                 client_name="UpdateClient", client_version="1.0.0"
             ),
             last_activity=datetime.now(timezone.utc),
-            identified_sessions={"update_session": user_identity},
             options=MCPCatOptions(),
         )
 
-        # Store data in server
         set_server_tracking_data(server, data)
 
-        # When passing data to get_session_info, it updates the stored data
         session_info = get_session_info(server, data)
 
-        # Verify the session info was properly constructed
-        assert session_info.identify_actor_given_id == "tracked_user"
-        assert session_info.identify_actor_name == "Tracked User"
-        assert session_info.identify_data == {"tracked": "yes"}
+        assert session_info.identify_actor_given_id is None
+        assert session_info.identify_actor_name is None
+        assert session_info.identify_data is None
 
         # Verify the data object was updated
         assert data.session_info == session_info

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -43,7 +43,6 @@ class TestStatelessMode:
             session_id="ses_existing123",
             session_info=SessionInfo(),
             last_activity=datetime.now(timezone.utc),
-            identified_sessions={},
             options=options,
             is_stateless=stateless,
         )
@@ -86,18 +85,8 @@ class TestStatelessMode:
         assert result.user_name == "Test User"
 
     @patch("mcpcat.modules.identify.event_queue")
-    def test_stateless_identify_no_shared_state(self, mock_event_queue):
-        """In stateless mode, identified_sessions should remain empty."""
-        self._setup_data(stateless=True, identify=_make_identify_fn())
-
-        identify_session(self.server, MagicMock(), MagicMock())
-
-        data = get_server_tracking_data(self.server)
-        assert data.identified_sessions == {}
-
-    @patch("mcpcat.modules.identify.event_queue")
-    def test_stateful_unchanged(self, mock_event_queue):
-        """Default (stateful) mode: session_id is a string, identify guard skips second call."""
+    def test_stateful_identify_runs_every_time(self, mock_event_queue):
+        """Stateful mode runs identify on every request."""
         mock_fn = MagicMock(return_value=UserIdentity(
             user_id="alice", user_name="Alice", user_data=None
         ))
@@ -108,13 +97,10 @@ class TestStatelessMode:
         assert isinstance(session_id, str)
         assert session_id.startswith("ses_")
 
-        # First identify call should work
         identify_session(self.server, MagicMock(), MagicMock())
-        assert mock_fn.call_count == 1
+        identify_session(self.server, MagicMock(), MagicMock())
 
-        # Second call should be skipped (early-return guard)
-        identify_session(self.server, MagicMock(), MagicMock())
-        assert mock_fn.call_count == 1
+        assert mock_fn.call_count == 2
 
     def test_track_stateless_true_sets_flag(self):
         """track() with stateless=True should set is_stateless on data."""


### PR DESCRIPTION
## Summary

- Collapses the stateful/stateless split in `identify_session` so the configured identify hook runs on **every MCP request** in both modes. Matches the TypeScript SDK and lets customers refresh identity mid-session (token rotation, impersonation, role changes).
- Removes `MCPCatData.identified_sessions` entirely. Identity is written directly onto each event by the handler that ran the hook; `publish_event`'s `exclude_none=True` merge preserves those fields.
- Publishes a `mcpcat:identify` self-event on every successful identification (one per normal event), so downstream analytics see a distinct identify marker per request.
- Wraps hook invocation, validation, event construction, and publish in a single `try/except` — `identify_session` can never raise into a tool call handler.
- `get_session_info` no longer carries identity fields; they are always `None`.

## Why

The previous stateful path ran the identify hook once per session and short-circuited all later requests, pinning identity to the first call's result and feeding hooks only the first request's context. Customers porting hooks between the Python and TypeScript SDKs hit surprising semantic differences. Unifying on per-event hook execution removes that asymmetry and makes identity reactive to per-request context.

## Test plan

- [x] Full suite: `uv run pytest tests/` — 349 passed, 2 unrelated skips
- [x] Identify-focused suites: `tests/test_stateless.py`, `tests/test_event_capture_completeness.py`, `tests/test_session.py`
- [x] Zero remaining references to `identified_sessions` anywhere in `src/` or `tests/`
- [ ] Manual smoke: run an MCP server with a stateful (stdio) and stateless (streamable HTTP) transport, configure an `identify` hook, and confirm the hook is invoked on every request and `mcpcat:identify` events appear 1:1 with normal events