### PR TITLE
fix(ci): allow transitive prereleases in FastMCP prerelease job

### DIFF
--- a/.github/workflows/mcp-prerelease-compatibility.yml
+++ b/.github/workflows/mcp-prerelease-compatibility.yml
@@ -103,9 +103,14 @@ jobs:
 
     - name: Install dependencies with prerelease FastMCP ${{ matrix.fastmcp-version }}
       run: |
-        # Install with both dev and community extras, allow prereleases
-        # FastMCP will determine which MCP version it needs
-        uv sync --extra dev --extra community --prerelease if-necessary-or-explicit
+        # Install with both dev and community extras, allow prereleases.
+        # FastMCP will determine which MCP version it needs.
+        # Use --prerelease=allow (not if-necessary-or-explicit): FastMCP 3.4+
+        # splits into fastmcp + a transitive fastmcp-slim package. Pinning a
+        # prerelease fastmcp pulls a matching prerelease fastmcp-slim that is
+        # not named in our pyproject, so if-necessary-or-explicit refuses it
+        # and resolution fails. "allow" is correct for a prerelease-testing job.
+        uv sync --extra dev --extra community --prerelease allow
 
     - name: Show installed versions
       run: |


### PR DESCRIPTION
## Summary
- The nightly **MCP Prerelease Compatibility** job has failed every night since FastMCP `3.4.0b1` landed on PyPI. The failure is in the **install step**, not a test — the `test-mcp-prerelease` job passes all tests; only the FastMCP job breaks.
- Root cause: FastMCP 3.4.0 restructured into `fastmcp` + a transitive `fastmcp-slim` package. Pinning `fastmcp==3.4.0b1` drags in a prerelease `fastmcp-slim==3.4.0b1` that isn't named in our `pyproject.toml`, so `uv sync --prerelease if-necessary-or-explicit` refuses it and resolution fails (`No solution found ... try: --prerelease=allow`).
- Fix: switch that one install step to `--prerelease allow`, the correct setting for a prerelease-testing job. The stable `mcp-compatibility.yml` workflow is unaffected (it uses no `--prerelease` flags).

There is **no SDK breaking change** — the full suite passes against FastMCP 3.4.0b1. The 3.4 change is purely a packaging split.

## Test plan
- [x] Reproduced exact CI error locally: `uv pip compile` with `if-necessary-or-explicit` fails identically
- [x] Confirmed `--prerelease allow` resolves: `fastmcp 3.4.0b1`, `fastmcp-slim 3.4.0b1`, `mcp 1.28.0`
- [x] Ran the exact CI command `uv sync --extra dev --extra community --prerelease allow` on a sed-modified pyproject → exit 0
- [x] Ran the full test suite against FastMCP 3.4.0b1 in an isolated venv → **436 passed, 4 skipped, 3 xfailed**
- [ ] Trigger the workflow via `workflow_dispatch` to confirm the nightly job goes green