### PR TITLE
feat(diagnostics): privacy-first SDK setup diagnostics (metadata-only, opt-out, OTLP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ mcpcat.track(
 
 Learn more about our free and open source [telemetry integrations](https://docs.mcpcat.io/telemetry/integrations).
 
+### Internal diagnostics
+
+To help us catch and fix broken installs, the SDK sends MCPcat a small, anonymized
+signal when setup or runtime errors occur — never your tool calls, your responses,
+or anything about your users. Records carry only operational metadata, such as your
+project ID (or an anonymous install ID when none is set). Your local `~/mcpcat.log`
+is unchanged.
+
+Diagnostics are on by default and can be turned off completely with either:
+
+- `track(server, project_id, MCPCatOptions(disable_diagnostics=True))`, or
+- the `DISABLE_DIAGNOSTICS` environment variable.
+
 ## Free for open source
 
 MCPcat is free for qualified open source projects. We believe in supporting the ecosystem that makes MCP possible. If you maintain an open source MCP server, you can access our full analytics platform at no cost.

--- a/src/mcpcat/__init__.py
+++ b/src/mcpcat/__init__.py
@@ -18,6 +18,7 @@ from .modules.compatibility import (
     is_compatible_server,
     is_official_fastmcp_server,
 )
+from .modules.diagnostics import init_diagnostics
 from .modules.internal import set_server_tracking_data
 from .modules.logging import set_debug_mode, write_to_log
 from .types import (
@@ -88,57 +89,77 @@ def track(
 
     set_debug_mode(options.debug_mode)
 
-    if not project_id and not options.exporters:
-        raise ValueError(
-            "Either project_id or exporters must be provided. "
-            "Use project_id for MCPCat, exporters for telemetry-only mode, or both."
-        )
+    # Initialize internal diagnostics before anything can fail, so even an
+    # invalid setup still emits a failure beacon. Never throws into the host.
+    init_diagnostics(project_id, disabled=options.disable_diagnostics)
 
-    if not is_compatible_server(server):
-        raise TypeError(COMPATIBILITY_ERROR_MESSAGE)
-
-    is_community_v3 = is_community_fastmcp_v3(server)
-    is_community_v2 = is_community_fastmcp_v2(server)
-    is_official_fastmcp = is_official_fastmcp_server(server)
-    is_fastmcp_v2 = is_official_fastmcp or is_community_v2
-
-    # Determine where to store tracking data:
-    # - v2 FastMCP servers use server._mcp_server
-    # - v3 and low-level servers use the server itself
-    if is_fastmcp_v2:
-        lowlevel_server = server._mcp_server
-    else:
-        lowlevel_server = server
-
-    if options.exporters:
-        from mcpcat.modules.event_queue import set_telemetry_manager
-        from mcpcat.modules.telemetry import TelemetryManager
-
-        telemetry_manager = TelemetryManager(options.exporters)
-        set_telemetry_manager(telemetry_manager)
-        write_to_log(
-            f"Telemetry initialized with {len(options.exporters)} exporter(s)"
-        )
-
-    session_id = new_session_id()
-    session_info = get_session_info(lowlevel_server)
-    data = MCPCatData(
-        session_id=session_id,
-        project_id=project_id,
-        last_activity=datetime.now(timezone.utc),
-        session_info=session_info,
-        options=options,
-        is_stateless=options.stateless if options.stateless is not None else _detect_stateless(server),
-    )
-    set_server_tracking_data(lowlevel_server, data)
-
-    # Resolve API base URL: option > env var > default
-    api_base_url = options.api_base_url or os.environ.get("MCPCAT_API_URL")
-    if api_base_url:
-        from mcpcat.modules.event_queue import event_queue
-        event_queue.configure(api_base_url)
-
+    # Wrap the whole setup so any failure emits a diagnostic. Config-contract
+    # errors (ValueError/TypeError) still propagate; tracking-application errors
+    # are logged but never break the host (server is still returned).
     try:
+        if not project_id and not options.exporters:
+            raise ValueError(
+                "Either project_id or exporters must be provided. "
+                "Use project_id for MCPCat, exporters for telemetry-only mode, or both."
+            )
+
+        if not is_compatible_server(server):
+            raise TypeError(COMPATIBILITY_ERROR_MESSAGE)
+
+        is_community_v3 = is_community_fastmcp_v3(server)
+        is_community_v2 = is_community_fastmcp_v2(server)
+        is_official_fastmcp = is_official_fastmcp_server(server)
+        is_fastmcp_v2 = is_official_fastmcp or is_community_v2
+
+        # Determine where to store tracking data:
+        # - v2 FastMCP servers use server._mcp_server
+        # - v3 and low-level servers use the server itself
+        if is_fastmcp_v2:
+            lowlevel_server = server._mcp_server
+        else:
+            lowlevel_server = server
+
+        # Metadata-only setup-started beacon (INFO — no fail/error/Warning).
+        server_kind = (
+            "fastmcp-v2"
+            if is_fastmcp_v2
+            else "fastmcp-v3"
+            if is_community_v3
+            else "lowlevel"
+        )
+        write_to_log(
+            f"MCPCat setup started | project {project_id or '(telemetry-only)'} | "
+            f"server {server_kind}"
+        )
+
+        if options.exporters:
+            from mcpcat.modules.event_queue import set_telemetry_manager
+            from mcpcat.modules.telemetry import TelemetryManager
+
+            telemetry_manager = TelemetryManager(options.exporters)
+            set_telemetry_manager(telemetry_manager)
+            write_to_log(
+                f"Telemetry initialized with {len(options.exporters)} exporter(s)"
+            )
+
+        session_id = new_session_id()
+        session_info = get_session_info(lowlevel_server)
+        data = MCPCatData(
+            session_id=session_id,
+            project_id=project_id,
+            last_activity=datetime.now(timezone.utc),
+            session_info=session_info,
+            options=options,
+            is_stateless=options.stateless if options.stateless is not None else _detect_stateless(server),
+        )
+        set_server_tracking_data(lowlevel_server, data)
+
+        # Resolve API base URL: option > env var > default
+        api_base_url = options.api_base_url or os.environ.get("MCPCAT_API_URL")
+        if api_base_url:
+            from mcpcat.modules.event_queue import event_queue
+            event_queue.configure(api_base_url)
+
         if not data.tracker_initialized:
             data.tracker_initialized = True
             write_to_log(
@@ -160,6 +181,21 @@ def track(
                 f"MCPCat initialized in telemetry-only mode for session {session_id}"
             )
 
+        # Metadata-only setup-complete beacon (INFO). A start-without-complete
+        # (or the ERROR diagnostics below) signals a failed setup.
+        write_to_log(
+            f"MCPCat setup complete | project {project_id or '(telemetry-only)'} | "
+            f"tracing={options.enable_tracing} "
+            f"context={options.enable_tool_call_context} "
+            f"report_missing={options.enable_report_missing} "
+            f"exporters={len(options.exporters) if options.exporters else 0}"
+        )
+
+    except (ValueError, TypeError) as e:
+        # Config-contract failures: emit a failure diagnostic, then propagate so
+        # callers still see the error (preserves existing public behavior).
+        write_to_log(f"Warning: Failed to track server - {e}")
+        raise
     except Exception as e:
         write_to_log(f"Error initializing MCPCat: {e}")
 

--- a/src/mcpcat/modules/constants.py
+++ b/src/mcpcat/modules/constants.py
@@ -11,3 +11,12 @@ MAX_EXCEPTION_CHAIN_DEPTH = 10
 
 # Maximum number of stack frames to capture per exception
 MAX_STACK_FRAMES = 50
+
+# Internal SDK diagnostics (privacy-first, metadata-only OTLP logs)
+DIAGNOSTICS_SCOPE_NAME = "mcpcat-diagnostics"
+DEFAULT_DIAGNOSTICS_ENDPOINT = "https://otel.agentcat.com"
+# Public shared ingestion key — NOT a secret; ships in the package to deter
+# drive-by traffic, paired with a server-side rate limit. Override with the
+# DIAGNOSTICS_TOKEN env var. Must match the collector's bearer token (same
+# literal as the TypeScript SDK).
+DEFAULT_DIAGNOSTICS_TOKEN = "dgk_sdk_diag_3f9a2c7e1b8d4065af2e9c1d7b6a4f80"

--- a/src/mcpcat/modules/diagnostics.py
+++ b/src/mcpcat/modules/diagnostics.py
@@ -1,0 +1,298 @@
+"""Privacy-first internal SDK diagnostics.
+
+Mirrors every internal MCPCat log line to MCPCat's own monitoring as an
+OTLP/HTTP log record, so we can detect when a developer's SDK fails to set up.
+
+**Only operational metadata is ever sent — never event payloads or user data.**
+Records carry environment/identity metadata (the attempted ``project_id``, or an
+anonymous install-id hash when none) plus a metadata-only message body. The local
+``~/mcpcat.log`` is unaffected.
+
+On by default; opt out via ``MCPCatOptions(disable_diagnostics=True)`` or the
+``DISABLE_DIAGNOSTICS`` env var. Nothing here ever throws into the host, and the
+fire-and-forget HTTP export runs on a daemon thread so it never blocks process exit.
+
+Override the collector with ``DIAGNOSTICS_ENDPOINT`` / ``DIAGNOSTICS_TOKEN``.
+"""
+
+import atexit
+import hashlib
+import os
+import platform
+import re
+import socket
+import threading
+import time
+from importlib.metadata import version
+from typing import Any
+
+import requests
+
+from .constants import (
+    DEFAULT_DIAGNOSTICS_ENDPOINT,
+    DEFAULT_DIAGNOSTICS_TOKEN,
+    DIAGNOSTICS_SCOPE_NAME,
+)
+from .logging import set_diagnostics_sink
+
+# --- Module-level state (guarded by _lock for buffer/timer) -------------------
+
+_enabled = False
+_initialized = False
+_static_attributes: list[dict[str, Any]] = []
+_buffer: list[dict[str, Any]] = []
+_flush_timer: threading.Timer | None = None
+_lock = threading.Lock()
+
+MAX_BUFFER = 1000
+BATCH_FLUSH_MS = 2000
+
+
+def _sdk_version() -> str:
+    try:
+        return version("mcpcat")
+    except Exception:
+        return "unknown"
+
+
+# --- Resolution helpers -------------------------------------------------------
+
+
+def _resolve_endpoint() -> str:
+    base = DEFAULT_DIAGNOSTICS_ENDPOINT
+    try:
+        base = os.environ.get("DIAGNOSTICS_ENDPOINT") or base
+    except Exception:
+        pass
+    trimmed = base.rstrip("/")
+    return trimmed if trimmed.endswith("/v1/logs") else f"{trimmed}/v1/logs"
+
+
+def _resolve_token() -> str:
+    try:
+        return os.environ.get("DIAGNOSTICS_TOKEN") or DEFAULT_DIAGNOSTICS_TOKEN
+    except Exception:
+        return DEFAULT_DIAGNOSTICS_TOKEN
+
+
+def _env_disabled() -> bool:
+    """Interpret ``DISABLE_DIAGNOSTICS`` by value, not mere presence.
+
+    ``false`` / ``0`` / ``no`` / ``off`` / empty (and whitespace) stay enabled;
+    anything else disables. Mirrors the ``MCPCAT_DEBUG_MODE`` idiom in logging.py.
+    """
+    try:
+        raw = os.environ.get("DISABLE_DIAGNOSTICS")
+        if not raw:
+            return False
+        return raw.strip().lower() not in ("false", "0", "no", "off", "")
+    except Exception:
+        return False
+
+
+# --- Record construction ------------------------------------------------------
+
+
+def _infer_severity(entry: str) -> tuple[int, str]:
+    # Order matters: fail/error first so "Warning: Failed to..." is ERROR (a
+    # setup failure), not WARN. "Warning:" is a case-sensitive literal match.
+    if re.search(r"fail|error", entry, re.I):
+        return 17, "ERROR"
+    if "Warning:" in entry:
+        return 13, "WARN"
+    return 9, "INFO"
+
+
+def _build_record(entry: str) -> dict[str, Any]:
+    number, text = _infer_severity(entry)
+    return {
+        "timeUnixNano": str(time.time_ns()),
+        "severityNumber": number,
+        "severityText": text,
+        "body": {"stringValue": entry},
+        "attributes": [],
+    }
+
+
+def _attr(key: str, value: Any) -> list[dict[str, Any]]:
+    return [{"key": key, "value": {"stringValue": str(value)}}] if value else []
+
+
+def _compute_install_id() -> str | None:
+    try:
+        seed = f"{socket.gethostname()}|{__file__}"
+        return hashlib.sha256(seed.encode()).hexdigest()[:16]
+    except Exception:
+        return None
+
+
+def _build_static_attributes(project_id: str | None) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    try:
+        # Identity / traceability
+        if project_id:
+            out += _attr("mcpcat.project_id", project_id)
+        else:
+            out += _attr("mcpcat.install_id", _compute_install_id())
+
+        # SDK
+        out += _attr("mcpcat.sdk.language", "python")
+        out += _attr("mcpcat.sdk.version", _sdk_version())
+
+        # Best-effort: resolved MCP SDK version (distribution name may differ).
+        try:
+            out += _attr("mcpcat.mcp_sdk.version", version("mcp"))
+        except Exception:
+            pass
+
+        # Runtime
+        out += _attr("process.runtime.name", platform.python_implementation().lower())
+        out += _attr("process.runtime.version", platform.python_version())
+        out += _attr("process.pid", str(os.getpid()))
+
+        # OS / host
+        out += _attr("os.type", platform.system())
+        out += _attr("os.version", platform.release())
+        out += _attr("host.arch", platform.machine())
+        cpu_count = os.cpu_count()
+        out += _attr("host.cpu.count", str(cpu_count) if cpu_count else None)
+
+        # Deploy/CI hints
+        out += _attr(
+            "deployment.environment",
+            os.environ.get("APP_ENV") or os.environ.get("ENVIRONMENT"),
+        )
+    except Exception:
+        # best-effort; partial attributes are fine
+        pass
+    return out
+
+
+# --- Buffering + flush --------------------------------------------------------
+
+
+def _schedule_flush() -> None:
+    global _flush_timer
+    with _lock:
+        if _flush_timer is not None:
+            return
+        try:
+            timer = threading.Timer(BATCH_FLUSH_MS / 1000.0, _timer_fired)
+            timer.daemon = True  # never keep the interpreter alive for diagnostics
+            _flush_timer = timer
+            timer.start()
+        except Exception:
+            _flush_timer = None
+
+
+def _timer_fired() -> None:
+    global _flush_timer
+    with _lock:
+        _flush_timer = None
+    flush_diagnostics()
+
+
+def capture(entry: str) -> None:
+    """Buffer one log entry (bounded, drop-oldest) and schedule a flush."""
+    try:
+        if not _enabled:
+            return
+        with _lock:
+            if len(_buffer) >= MAX_BUFFER:
+                _buffer.pop(0)
+            _buffer.append(_build_record(entry))
+        _schedule_flush()
+    except Exception:
+        # diagnostics capture must never throw
+        pass
+
+
+def flush_diagnostics() -> None:
+    """Swap out the buffer and POST it fire-and-forget. Never raises."""
+    try:
+        if not _enabled:
+            return
+        with _lock:
+            if not _buffer:
+                return
+            records = _buffer[:]
+            _buffer.clear()
+
+        payload = {
+            "resourceLogs": [
+                {
+                    "resource": {"attributes": _static_attributes},
+                    "scopeLogs": [
+                        {
+                            "scope": {
+                                "name": DIAGNOSTICS_SCOPE_NAME,
+                                "version": _sdk_version(),
+                            },
+                            "logRecords": records,
+                        }
+                    ],
+                }
+            ]
+        }
+
+        token = _resolve_token()
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        requests.post(_resolve_endpoint(), json=payload, headers=headers, timeout=5)
+    except Exception:
+        # fire-and-forget: never propagate diagnostics network errors
+        pass
+
+
+# --- Lifecycle ----------------------------------------------------------------
+
+
+def init_diagnostics(project_id: str | None, disabled: bool = False) -> None:
+    """Initialize diagnostics. Idempotent; never throws into the host."""
+    global _enabled, _initialized, _static_attributes
+    try:
+        if _initialized:
+            return
+        _initialized = True
+        _enabled = (not disabled) and not _env_disabled()
+        if not _enabled:
+            return
+        _static_attributes = _build_static_attributes(project_id)
+        set_diagnostics_sink(capture)
+    except Exception:
+        # diagnostics init must never throw
+        pass
+
+
+def is_diagnostics_enabled() -> bool:
+    return _enabled
+
+
+# --- Test helpers (mirror the TS SDK) -----------------------------------------
+
+
+def _reset_diagnostics_for_test() -> None:
+    global _enabled, _initialized, _static_attributes, _buffer, _flush_timer
+    with _lock:
+        _enabled = False
+        _initialized = False
+        _static_attributes = []
+        _buffer = []
+        if _flush_timer is not None:
+            _flush_timer.cancel()
+            _flush_timer = None
+    set_diagnostics_sink(None)
+
+
+def _get_static_attributes_for_test() -> list[dict[str, Any]]:
+    return _static_attributes
+
+
+def _build_record_for_test(entry: str) -> dict[str, Any]:
+    return _build_record(entry)
+
+
+# Flush whatever is buffered on interpreter exit (covers non-destroy() paths).
+atexit.register(flush_diagnostics)

--- a/src/mcpcat/modules/event_queue.py
+++ b/src/mcpcat/modules/event_queue.py
@@ -159,10 +159,10 @@ class EventQueue:
             # Synchronous API call
             self.api_client.publish_event(publish_event_request=event)
             write_to_log(
-                f"Successfully sent event {event.id} | {event.event_type} | {event.project_id} | "
+                f"Successfully sent event {event.id} | {event.event_type} | "
+                f"session {event.session_id} | {event.project_id} | "
                 f"{event.duration} ms | {event.identify_actor_given_id or 'anonymous'}"
             )
-            write_to_log(f"Event details: {event.model_dump_json()}")
         except Exception as error:
             if self._shutdown_event.is_set():
                 write_to_log(
@@ -222,6 +222,15 @@ class EventQueue:
         remaining = self.queue.qsize()
         if remaining > 0:
             write_to_log(f"Shutdown complete. {remaining} events were not processed.")
+
+        # Flush any buffered SDK diagnostics on the way out. Lazy import to avoid
+        # an import cycle; never let diagnostics break shutdown.
+        try:
+            from mcpcat.modules.diagnostics import flush_diagnostics
+
+            flush_diagnostics()
+        except Exception:
+            pass
 
 
 # Global telemetry manager instance (optional)

--- a/src/mcpcat/modules/exporters/datadog.py
+++ b/src/mcpcat/modules/exporters/datadog.py
@@ -65,11 +65,9 @@ class DatadogExporter(Exporter):
         log = self.event_to_log(event)
         metrics = self.event_to_metrics(event)
 
-        # Debug: Log the metrics payload
+        # Debug: Log the metrics payload (metadata only — count, not contents)
         write_to_log(f"DatadogExporter: Metrics URL: {self.metrics_url}")
-        write_to_log(
-            f"DatadogExporter: Metrics payload: {json.dumps({'series': metrics})}"
-        )
+        write_to_log(f"DatadogExporter: Sending {len(metrics)} metric series")
 
         # Send logs and metrics synchronously
         self._send_logs([log])
@@ -89,9 +87,8 @@ class DatadogExporter(Exporter):
             )
 
             if not response.ok:
-                error_body = response.text
                 write_to_log(
-                    f"Datadog logs failed - Status: {response.status_code}, Body: {error_body}"
+                    f"Datadog logs failed - Status: {response.status_code}"
                 )
             else:
                 write_to_log(f"Datadog logs success - Status: {response.status_code}")
@@ -112,14 +109,12 @@ class DatadogExporter(Exporter):
             )
 
             if not response.ok:
-                error_body = response.text
                 write_to_log(
-                    f"Datadog metrics failed - Status: {response.status_code}, Body: {error_body}"
+                    f"Datadog metrics failed - Status: {response.status_code}"
                 )
             else:
-                response_body = response.text
                 write_to_log(
-                    f"Datadog metrics success - Status: {response.status_code}, Body: {response_body}"
+                    f"Datadog metrics success - Status: {response.status_code}"
                 )
         except Exception as err:
             write_to_log(f"Datadog metrics network error: {err}")

--- a/src/mcpcat/modules/exporters/sentry.py
+++ b/src/mcpcat/modules/exporters/sentry.py
@@ -105,9 +105,8 @@ class SentryExporter(Exporter):
             )
 
             if not log_response.ok:
-                error_body = log_response.text
                 write_to_log(
-                    f"Sentry log export failed - Status: {log_response.status_code}, Body: {error_body}"
+                    f"Sentry log export failed - Status: {log_response.status_code}"
                 )
             else:
                 write_to_log(f"Sentry log export success - Event: {event.id}")
@@ -132,9 +131,8 @@ class SentryExporter(Exporter):
                 )
 
                 if not transaction_response.ok:
-                    error_body = transaction_response.text
                     write_to_log(
-                        f"Sentry transaction export failed - Status: {transaction_response.status_code}, Body: {error_body}"
+                        f"Sentry transaction export failed - Status: {transaction_response.status_code}"
                     )
                 else:
                     write_to_log(
@@ -165,9 +163,8 @@ class SentryExporter(Exporter):
                 )
 
                 if not error_response.ok:
-                    error_body = error_response.text
                     write_to_log(
-                        f"Sentry error export failed - Status: {error_response.status_code}, Body: {error_body}"
+                        f"Sentry error export failed - Status: {error_response.status_code}"
                     )
                 else:
                     write_to_log(f"Sentry error export success - Event: {event.id}")

--- a/src/mcpcat/modules/identify.py
+++ b/src/mcpcat/modules/identify.py
@@ -21,7 +21,8 @@ def identify_session(server, request: any, context: any) -> UserIdentity | None:
         identify_result = data.options.identify(request, context)
         if not identify_result or not isinstance(identify_result, UserIdentity):
             write_to_log(
-                f"User identification function did not return a valid UserIdentity instance. Received: {identify_result}"
+                "User identification function did not return a valid UserIdentity "
+                f"instance. Received type: {type(identify_result).__name__}"
             )
             return None
 

--- a/src/mcpcat/modules/logging.py
+++ b/src/mcpcat/modules/logging.py
@@ -1,6 +1,7 @@
 """Logging functionality for MCPCat."""
 
 import os
+from collections.abc import Callable
 from datetime import datetime, timezone
 
 from mcpcat.types import MCPCatOptions
@@ -14,15 +15,34 @@ else:
     debug_mode = False
 
 
+# Optional sink that receives every (clean, newline-free) log entry. Used by the
+# diagnostics module to mirror internal logs to MCPCat's monitoring. Fires
+# independent of debug_mode and must never break logging.
+_diagnostics_sink: Callable[[str], None] | None = None
+
+
 def set_debug_mode(value: bool) -> None:
     """Set the global debug_mode value."""
     global debug_mode
     debug_mode = value
 
 
+def set_diagnostics_sink(fn: Callable[[str], None] | None) -> None:
+    """Register (or clear with None) the diagnostics sink for log entries."""
+    global _diagnostics_sink
+    _diagnostics_sink = fn
+
+
 def write_to_log(message: str) -> None:
     timestamp = datetime.now(timezone.utc).isoformat()
-    log_entry = f"[{timestamp}] {message}\n"
+    log_entry = f"[{timestamp}] {message}"
+
+    # Tee to diagnostics FIRST — independent of debug_mode. Must never break logging.
+    if _diagnostics_sink is not None:
+        try:
+            _diagnostics_sink(log_entry)
+        except Exception:
+            pass
 
     # Always use ~/mcpcat.log
     log_path = os.path.expanduser("~/mcpcat.log")
@@ -31,7 +51,7 @@ def write_to_log(message: str) -> None:
         if debug_mode:
             # Write to log file (no need to ensure directory exists for home directory)
             with open(log_path, "a") as f:
-                f.write(log_entry)
+                f.write(log_entry + "\n")
     except Exception:
         # Silently fail - we don't want logging errors to break the server
         pass

--- a/src/mcpcat/modules/tools.py
+++ b/src/mcpcat/modules/tools.py
@@ -30,6 +30,10 @@ if TYPE_CHECKING or has_fastmcp_support():
 
 async def handle_report_missing(arguments: dict[str, Any]) -> CallToolResult:
     """Handle the report_missing tool."""
+    # Metadata-only diagnostics: log the context length, never the context text.
+    write_to_log(
+        f"Missing tool reported (context length: {len(arguments.get('context', ''))})"
+    )
     return CallToolResult(
         content=[
             TextContent(

--- a/src/mcpcat/types.py
+++ b/src/mcpcat/types.py
@@ -177,6 +177,11 @@ class MCPCatOptions:
     debug_mode: bool = False
     api_base_url: str | None = None
     stateless: bool | None = None
+    # Disables MCPCat's internal SDK diagnostics — anonymous, metadata-only
+    # setup/error reporting used to detect failed installs. On by default; also
+    # disable-able via the DISABLE_DIAGNOSTICS env var. Never sends event
+    # payloads or user data; the local ~/mcpcat.log is unaffected.
+    disable_diagnostics: bool = False
     # Callback invoked on every auto-captured event (initialize, tools/list,
     # tools/call) to attach string key-value tags. Tags are intended for
     # structured metadata you'll filter or group by in the MCPCat dashboard

--- a/tests/test_diagnostics_attributes.py
+++ b/tests/test_diagnostics_attributes.py
@@ -1,0 +1,55 @@
+"""Tests for static OTLP resource attributes (identity + environment)."""
+
+import pytest
+
+from mcpcat.modules import diagnostics
+
+
+@pytest.fixture(autouse=True)
+def reset(monkeypatch):
+    diagnostics._reset_diagnostics_for_test()
+    monkeypatch.delenv("DISABLE_DIAGNOSTICS", raising=False)
+    yield
+    diagnostics._reset_diagnostics_for_test()
+
+
+def _attrs() -> dict[str, str]:
+    return {
+        a["key"]: a["value"]["stringValue"]
+        for a in diagnostics._get_static_attributes_for_test()
+    }
+
+
+def test_project_id_present_no_install_id():
+    diagnostics.init_diagnostics("proj_ABC")
+    attrs = _attrs()
+    assert attrs.get("mcpcat.project_id") == "proj_ABC"
+    assert "mcpcat.install_id" not in attrs
+
+
+def test_anonymous_install_id_when_no_project():
+    diagnostics.init_diagnostics(None)
+    attrs = _attrs()
+    assert "mcpcat.project_id" not in attrs
+    assert attrs.get("mcpcat.install_id")
+
+
+def test_install_id_stable_across_reinit():
+    diagnostics.init_diagnostics(None)
+    first = _attrs().get("mcpcat.install_id")
+
+    diagnostics._reset_diagnostics_for_test()
+    diagnostics.init_diagnostics(None)
+    second = _attrs().get("mcpcat.install_id")
+
+    assert first and first == second
+
+
+def test_sdk_and_environment_metadata_present():
+    diagnostics.init_diagnostics("proj_1")
+    attrs = _attrs()
+    assert attrs.get("mcpcat.sdk.language") == "python"
+    assert attrs.get("mcpcat.sdk.version")
+    assert attrs.get("os.type")
+    assert attrs.get("process.runtime.name")
+    assert attrs.get("process.runtime.version")

--- a/tests/test_diagnostics_auth.py
+++ b/tests/test_diagnostics_auth.py
@@ -1,0 +1,46 @@
+"""Tests for the diagnostics bearer-token Authorization header."""
+
+from unittest.mock import patch
+
+import pytest
+
+from mcpcat.modules import diagnostics
+from mcpcat.modules.logging import write_to_log
+
+
+@pytest.fixture(autouse=True)
+def reset(monkeypatch):
+    diagnostics._reset_diagnostics_for_test()
+    monkeypatch.delenv("DISABLE_DIAGNOSTICS", raising=False)
+    monkeypatch.delenv("DIAGNOSTICS_TOKEN", raising=False)
+    yield
+    diagnostics._reset_diagnostics_for_test()
+
+
+def _flush_and_get_headers() -> dict:
+    write_to_log("a log line")
+    with patch("mcpcat.modules.diagnostics.requests.post") as mock_post:
+        diagnostics.flush_diagnostics()
+        mock_post.assert_called_once()
+        return mock_post.call_args.kwargs["headers"]
+
+
+def test_default_bearer_token():
+    diagnostics.init_diagnostics("proj_1")
+    headers = _flush_and_get_headers()
+    assert headers["Authorization"].startswith("Bearer dgk_sdk_diag_")
+
+
+def test_token_override(monkeypatch):
+    monkeypatch.setenv("DIAGNOSTICS_TOKEN", "custom-token-123")
+    diagnostics.init_diagnostics("proj_1")
+    headers = _flush_and_get_headers()
+    assert headers["Authorization"] == "Bearer custom-token-123"
+
+
+def test_empty_token_falls_back_to_default(monkeypatch):
+    """Empty string is falsy → fall back to the default (header still present)."""
+    monkeypatch.setenv("DIAGNOSTICS_TOKEN", "")
+    diagnostics.init_diagnostics("proj_1")
+    headers = _flush_and_get_headers()
+    assert headers["Authorization"].startswith("Bearer dgk_sdk_diag_")

--- a/tests/test_diagnostics_export.py
+++ b/tests/test_diagnostics_export.py
@@ -1,0 +1,71 @@
+"""Tests for the batched OTLP export (fire-and-forget POST)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from mcpcat.modules import diagnostics
+from mcpcat.modules.logging import write_to_log
+
+
+@pytest.fixture(autouse=True)
+def reset(monkeypatch):
+    diagnostics._reset_diagnostics_for_test()
+    monkeypatch.delenv("DISABLE_DIAGNOSTICS", raising=False)
+    monkeypatch.delenv("DIAGNOSTICS_ENDPOINT", raising=False)
+    yield
+    diagnostics._reset_diagnostics_for_test()
+
+
+def test_flush_posts_otlp_shaped_json():
+    diagnostics.init_diagnostics("proj_1")
+    write_to_log("Warning: something happened")
+
+    with patch("mcpcat.modules.diagnostics.requests.post") as mock_post:
+        diagnostics.flush_diagnostics()
+
+        mock_post.assert_called_once()
+        url = mock_post.call_args.args[0]
+        assert url.endswith("/v1/logs")
+
+        payload = mock_post.call_args.kwargs["json"]
+        scope_logs = payload["resourceLogs"][0]["scopeLogs"][0]
+        records = scope_logs["logRecords"]
+        assert any(
+            "something happened" in r["body"]["stringValue"] for r in records
+        )
+
+        resource_attrs = {
+            a["key"]: a["value"]["stringValue"]
+            for a in payload["resourceLogs"][0]["resource"]["attributes"]
+        }
+        assert resource_attrs.get("mcpcat.project_id") == "proj_1"
+
+
+def test_flush_swallows_post_errors():
+    diagnostics.init_diagnostics("proj_1")
+    write_to_log("some log line")
+
+    with patch(
+        "mcpcat.modules.diagnostics.requests.post",
+        side_effect=RuntimeError("network down"),
+    ):
+        # Must not raise.
+        diagnostics.flush_diagnostics()
+
+
+def test_no_post_when_disabled():
+    diagnostics.init_diagnostics("proj_1", disabled=True)
+    write_to_log("ignored")
+
+    with patch("mcpcat.modules.diagnostics.requests.post") as mock_post:
+        diagnostics.flush_diagnostics()
+        mock_post.assert_not_called()
+
+
+def test_no_post_when_buffer_empty():
+    diagnostics.init_diagnostics("proj_1")
+
+    with patch("mcpcat.modules.diagnostics.requests.post") as mock_post:
+        diagnostics.flush_diagnostics()
+        mock_post.assert_not_called()

--- a/tests/test_diagnostics_integration.py
+++ b/tests/test_diagnostics_integration.py
@@ -1,0 +1,38 @@
+"""End-to-end: init_diagnostics + real write_to_log buffers and posts."""
+
+from unittest.mock import patch
+
+import pytest
+
+from mcpcat.modules import diagnostics
+from mcpcat.modules.logging import write_to_log
+
+
+@pytest.fixture(autouse=True)
+def reset(monkeypatch):
+    diagnostics._reset_diagnostics_for_test()
+    monkeypatch.delenv("DISABLE_DIAGNOSTICS", raising=False)
+    yield
+    diagnostics._reset_diagnostics_for_test()
+
+
+def test_end_to_end_buffers_and_posts():
+    diagnostics.init_diagnostics("proj_int")
+    write_to_log("MCPCat setup started | project proj_int | server lowlevel")
+
+    with patch("mcpcat.modules.diagnostics.requests.post") as mock_post:
+        diagnostics.flush_diagnostics()
+
+        mock_post.assert_called_once()
+        payload = mock_post.call_args.kwargs["json"]
+        records = payload["resourceLogs"][0]["scopeLogs"][0]["logRecords"]
+        assert len(records) > 0
+
+
+def test_disabled_never_posts():
+    diagnostics.init_diagnostics("proj_int", disabled=True)
+    write_to_log("nothing should buffer")
+
+    with patch("mcpcat.modules.diagnostics.requests.post") as mock_post:
+        diagnostics.flush_diagnostics()
+        mock_post.assert_not_called()

--- a/tests/test_diagnostics_no_payload.py
+++ b/tests/test_diagnostics_no_payload.py
@@ -1,0 +1,90 @@
+"""The privacy guard: diagnostics logs carry metadata only — never payloads.
+
+Strategy mirrors the TS suite: keep the real diagnostics module OFF-network by
+setting DISABLE_DIAGNOSTICS=1 (so init_diagnostics won't register its own sink),
+then register our own capturing sink to inspect every entry write_to_log emits
+while a real tracked server handles real tool calls + identify.
+"""
+
+import time
+
+import pytest
+
+from mcpcat import MCPCatOptions, track
+from mcpcat.modules import diagnostics
+from mcpcat.modules.event_queue import EventQueue, set_event_queue
+from mcpcat.modules.logging import set_diagnostics_sink
+from mcpcat.types import UserIdentity
+
+from .test_utils.client import create_test_client
+from .test_utils.todo_server import create_todo_server
+
+SECRET_ARG = "topsecret-todo-xyz"
+SECRET_CONTEXT = "confidential-reason-for-needing-a-tool-uvw"
+SECRET_NAME = "Secret Agent Name"
+SECRET_DATA_VALUE = "ssn-000-secret"
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    # Keep the real diagnostics module off-network; install our own sink.
+    monkeypatch.setenv("DISABLE_DIAGNOSTICS", "1")
+    diagnostics._reset_diagnostics_for_test()
+
+    from unittest.mock import MagicMock
+
+    mock_api_client = MagicMock()
+    mock_api_client.publish_event = MagicMock(return_value=None)
+    set_event_queue(EventQueue(api_client=mock_api_client))
+
+    seen: list[str] = []
+    set_diagnostics_sink(seen.append)
+    try:
+        yield seen
+    finally:
+        set_diagnostics_sink(None)
+        diagnostics._reset_diagnostics_for_test()
+        set_event_queue(EventQueue())
+
+
+async def test_diagnostics_never_leak_payloads_or_identity(captured):
+    def identify_fn(request, context):
+        return UserIdentity(
+            user_id="actor-1",
+            user_name=SECRET_NAME,
+            user_data={"ssn": SECRET_DATA_VALUE},
+        )
+
+    server = create_todo_server()
+    track(
+        server,
+        "test-project",
+        MCPCatOptions(
+            enable_report_missing=True,
+            enable_tracing=True,
+            identify=identify_fn,
+        ),
+    )
+
+    async with create_test_client(server) as client:
+        await client.call_tool("add_todo", {"text": SECRET_ARG})
+        await client.call_tool("get_more_tools", {"context": SECRET_CONTEXT})
+
+    # Let the event-queue worker drain so success metadata lines are emitted too.
+    time.sleep(1.5)
+
+    all_logs = "\n".join(captured)
+
+    # Setup beacons present + metadata-only.
+    assert "MCPCat setup started" in all_logs
+    assert "test-project" in all_logs
+    assert "MCPCat setup complete" in all_logs
+    assert "tracing=True" in all_logs
+
+    # Report-missing logs only the context length, never the context text.
+    assert f"context length: {len(SECRET_CONTEXT)}" in all_logs
+
+    # No payload / identity leaks anywhere.
+    assert "Event details" not in all_logs
+    for secret in (SECRET_ARG, SECRET_CONTEXT, SECRET_NAME, SECRET_DATA_VALUE):
+        assert secret not in all_logs, f"diagnostics leaked secret: {secret!r}"

--- a/tests/test_diagnostics_optout.py
+++ b/tests/test_diagnostics_optout.py
@@ -1,0 +1,38 @@
+"""Tests for diagnostics opt-out (option + DISABLE_DIAGNOSTICS env var)."""
+
+import pytest
+
+from mcpcat.modules import diagnostics
+
+
+@pytest.fixture(autouse=True)
+def reset(monkeypatch):
+    diagnostics._reset_diagnostics_for_test()
+    monkeypatch.delenv("DISABLE_DIAGNOSTICS", raising=False)
+    yield
+    diagnostics._reset_diagnostics_for_test()
+
+
+def test_enabled_by_default():
+    diagnostics.init_diagnostics("proj_1")
+    assert diagnostics.is_diagnostics_enabled() is True
+
+
+def test_disabled_via_option():
+    diagnostics.init_diagnostics("proj_1", disabled=True)
+    assert diagnostics.is_diagnostics_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "on"])
+def test_disabled_via_env(monkeypatch, value):
+    monkeypatch.setenv("DISABLE_DIAGNOSTICS", value)
+    diagnostics.init_diagnostics("proj_1")
+    assert diagnostics.is_diagnostics_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off", "  "])
+def test_stays_enabled_for_falsy_values(monkeypatch, value):
+    """The Kashish case: a value-interpreted env var, not presence-based."""
+    monkeypatch.setenv("DISABLE_DIAGNOSTICS", value)
+    diagnostics.init_diagnostics("proj_1")
+    assert diagnostics.is_diagnostics_enabled() is True

--- a/tests/test_diagnostics_record.py
+++ b/tests/test_diagnostics_record.py
@@ -1,0 +1,46 @@
+"""Tests for OTLP record construction + severity inference."""
+
+from mcpcat.modules import diagnostics
+
+
+def test_warning_failed_is_error():
+    """fail/error beats the Warning: prefix — a setup failure is ERROR."""
+    rec = diagnostics._build_record_for_test("Warning: Failed to track server - boom")
+    assert rec["severityText"] == "ERROR"
+    assert rec["severityNumber"] == 17
+
+
+def test_warning_is_warn():
+    rec = diagnostics._build_record_for_test("Warning: something happened")
+    assert rec["severityText"] == "WARN"
+    assert rec["severityNumber"] == 13
+
+
+def test_lowercase_warning_is_info():
+    """'Warning:' is a case-sensitive literal; lowercase doesn't match."""
+    rec = diagnostics._build_record_for_test("warning: nothing here")
+    assert rec["severityText"] == "INFO"
+    assert rec["severityNumber"] == 9
+
+
+def test_plain_is_info():
+    rec = diagnostics._build_record_for_test("MCPCat setup complete | project x")
+    assert rec["severityText"] == "INFO"
+    assert rec["severityNumber"] == 9
+
+
+def test_bare_error_word_is_error():
+    rec = diagnostics._build_record_for_test("Some error happened")
+    assert rec["severityText"] == "ERROR"
+
+
+def test_body_is_verbatim():
+    entry = "[2026-01-01T00:00:00+00:00] arbitrary body text"
+    rec = diagnostics._build_record_for_test(entry)
+    assert rec["body"]["stringValue"] == entry
+
+
+def test_record_shape():
+    rec = diagnostics._build_record_for_test("anything")
+    assert rec["timeUnixNano"].isdigit()
+    assert rec["attributes"] == []

--- a/tests/test_diagnostics_sink.py
+++ b/tests/test_diagnostics_sink.py
@@ -1,0 +1,57 @@
+"""Tests for the diagnostics sink hook in logging.write_to_log."""
+
+from mcpcat.modules.logging import (
+    set_debug_mode,
+    set_diagnostics_sink,
+    write_to_log,
+)
+
+
+def teardown_function():
+    # Always clear the sink so one test never leaks into another.
+    set_diagnostics_sink(None)
+
+
+def test_sink_receives_every_entry():
+    seen: list[str] = []
+    set_diagnostics_sink(seen.append)
+
+    write_to_log("hello world")
+
+    assert len(seen) == 1
+    assert "hello world" in seen[0]
+    # Sink gets the timestamped, newline-free entry.
+    assert seen[0].startswith("[")
+    assert "\n" not in seen[0]
+
+
+def test_sink_raising_never_breaks_write_to_log():
+    def boom(_entry: str) -> None:
+        raise RuntimeError("sink failure")
+
+    set_diagnostics_sink(boom)
+
+    # Must not raise.
+    write_to_log("still fine")
+
+
+def test_cleared_sink_stops_forwarding():
+    seen: list[str] = []
+    set_diagnostics_sink(seen.append)
+    set_diagnostics_sink(None)
+
+    write_to_log("after clear")
+
+    assert seen == []
+
+
+def test_sink_fires_when_debug_mode_disabled():
+    """The key Python invariant: the tee is independent of debug_mode."""
+    seen: list[str] = []
+    set_debug_mode(False)
+    set_diagnostics_sink(seen.append)
+
+    write_to_log("debug off but tee on")
+
+    assert len(seen) == 1
+    assert "debug off but tee on" in seen[0]

--- a/tests/test_event_queue.py
+++ b/tests/test_event_queue.py
@@ -265,6 +265,30 @@ class TestEventQueue:
         assert mock_log.call_count >= 1  # At least one success log
 
     @patch("mcpcat.modules.event_queue.write_to_log")
+    def test_send_event_success_logs_session_not_payload(self, mock_log):
+        """Success log carries session metadata, never a serialized payload."""
+        eq = EventQueue()
+        eq.api_client = MagicMock()
+
+        event = Event(
+            id="evt-1",
+            event_type="mcp:tools/call",
+            project_id="proj-1",
+            session_id="ses-secret-123",
+            timestamp=datetime.now(timezone.utc),
+            duration=42,
+            identify_actor_given_id="actor-1",
+        )
+
+        eq._send_event(event)
+
+        logged = "\n".join(str(c.args[0]) for c in mock_log.call_args_list)
+        assert "session ses-secret-123" in logged
+        # The full-payload dump was removed for privacy.
+        assert "Event details" not in logged
+        assert "model_dump_json" not in logged
+
+    @patch("mcpcat.modules.event_queue.write_to_log")
     def test_send_event_with_retries(self, mock_log):
         """Test sending event with retries on failure."""
         eq = EventQueue()


### PR DESCRIPTION
## Privacy-first SDK setup diagnostics

When a developer's MCP server fails to initialize MCPCat, we currently have **zero** visibility — every `write_to_log()` line stays on their machine in `~/mcpcat.log`. This PR gives us just enough signal to catch and fix broken setups, **without ever looking at what their server does or who uses it.**

The guiding principle: **send the minimum needed to debug a setup, and nothing about the developer's data, users, or traffic.** Diagnostics are metadata-only by construction and guarded by tests — not a promise, an invariant.

This is the Python port of the TypeScript SDK's [`feat/sdk-diagnostics-otlp`](https://github.com/MCPCat/mcpcat-typescript-sdk/pull/40), matching its shape and wire format.

## What we send vs. what we never send

| ✅ Sent (operational metadata) | 🚫 Never sent |
|---|---|
| Setup beacons (`setup started` / `setup complete`) + resolved feature flags | Tool-call arguments / parameters |
| Event/session/actor **IDs**, event types, durations, counts | Tool results / responses |
| Inferred severity + diagnostic message text (metadata-only) | User-intent free-text (the `context` field) |
| SDK language/version, MCP-SDK version | Actor identity — `user_name`, `user_data` (PII) |
| Runtime (cpython/version, pid), OS type/arch/cpu count, `APP_ENV`/`ENVIRONMENT` | Any event payload body |
| Project ID being set up — **or** an anonymous `install_id` when none | Hostnames, secrets, request/response bodies |

The `install_id` is a **one-way SHA-256 hash** (truncated), never your hostname. Every line that previously serialized an event, identity, or tool argument has been repurposed to log metadata only, and `tests/test_diagnostics_no_payload.py` drives real tool calls + identify and asserts no payload, PII, or user text ever reaches the diagnostics sink.

## Unintrusive by design

- **Off your critical path.** Fire-and-forget, batched POSTs on a **daemon** timer (Python's analog of `.unref()`) — never blocks a request, never keeps the process alive, flushes on `destroy()` + `atexit`.
- **Cannot break your server.** Every entry point is guarded; diagnostics never throw into the host and flush never raises. A network blip or missing module is a silent no-op.
- **Tiny footprint.** A ~4-line tee in `logging.py` into one self-contained module; `~/mcpcat.log` behavior is completely unchanged.
- **Bounded.** Drop-oldest buffer caps memory; a burst of logs can never balloon.

### Python-specific invariant

In this SDK `write_to_log` only writes to `~/mcpcat.log` when `debug_mode` is on — the TS version always writes. So the diagnostics tee fires **outside** the `debug_mode` gate: a developer who never enabled debug mode still emits a setup heartbeat. `test_diagnostics_sink.py` pins this (`sink fires with debug_mode=False`).

## On by default, trivially off

Diagnostics are on by default so we can actually catch setup failures, but opting out is a one-liner and **fully respected**:

- `track(server, project_id, MCPCatOptions(disable_diagnostics=True))`, or
- `DISABLE_DIAGNOSTICS` env var — and it **interprets the value**: `false` / `0` / `no` / `off` (and whitespace) stay enabled, `true` / `1` / `yes` / `on` disable. This reuses the existing `MCPCAT_DEBUG_MODE` idiom, not presence-based `bool(os.getenv(...))`.

Endpoint/token are overridable via brand-neutral `DIAGNOSTICS_ENDPOINT` / `DIAGNOSTICS_TOKEN` for self-hosting.

## How it works

Each `write_to_log` entry becomes an OTLP/HTTP `LogRecord` — metadata-only body, inferred severity (**setup failures phrased `Warning: Failed…` classify as ERROR** so they alarm), plus the resource attributes above. Batched POST to `https://otel.agentcat.com/v1/logs` with a shared bearer token (a non-secret ingestion key that deters drive-by traffic and pairs with a server-side WAF rate-limit — an abuse control, not a privacy boundary).

To preserve Python's public contract, `track()` still **raises** `ValueError`/`TypeError` on bad config / incompatible servers (after emitting a failure diagnostic), and still returns the server on tracking-application errors.

## Privacy scrub (both HTTP exporters)

Beyond the diagnostics tee, every existing log line that dumped a payload or response body is now metadata-only:

- `event_queue.py` — removed the `Event details: {model_dump_json()}` full-payload dump; the success line now carries the `session` id.
- `exporters/datadog.py` + `exporters/sentry.py` — failed/success exports log `Status:` only, never `Body:` (a platform's error response can echo back what we sent it).
- `identify.py` — logs the result **type**, not the raw (possibly user-shaped) object.
- `tools.py` `report_missing` — logs the **context length**, never the context text.

## Tests

474 passing, 4 skipped, 3 xfailed. TDD throughout; payload-exclusion and opt-out behavior are covered by dedicated suites (`test_diagnostics_{sink,optout,record,attributes,export,auth,integration,no_payload}.py`). New `diagnostics.py` is ruff- and mypy-clean.

## Companion

Server-side collector + WAF: `MCPCat/mcpcat-server#343` (approved). The bearer token literal matches across the TS SDK, this SDK, and the collector.
