### PR TITLE
The final mcpcat release — this SDK is now agentcat 🐱

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> **MCPcat is now AgentCat** 🐱 — same team, same product, new name. This package has been renamed to [`agentcat`](https://pypi.org/project/agentcat/) (`pip install agentcat`, starts at v1.0.0). `mcpcat` keeps working forever, but new features land only in `agentcat`. Upgrading takes a few minutes — see the [migration guide](./MIGRATION.md).
+
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/static/logo-dark.svg">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mcpcat"
-version = "0.1.15b2"
-description = "Analytics Tool for MCP Servers - provides insights into MCP tool usage patterns"
+version = "0.1.15"
+description = "DEPRECATED — renamed to 'agentcat' (pip install agentcat). Analytics Tool for MCP Servers - provides insights into MCP tool usage patterns"
 authors = [
     { name = "MCPCat", email = "support@mcpcat.io" },
 ]
@@ -9,7 +9,7 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.10"
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 7 - Inactive",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -28,6 +28,7 @@ dependencies = [
 "Homepage" = "https://github.com/MCPCat/mcpcat-python-sdk"
 "Bug Tracker" = "https://github.com/MCPCat/mcpcat-python-sdk/issues"
 "Repository" = "https://github.com/MCPCat/mcpcat-python-sdk"
+"Migration" = "https://pypi.org/project/agentcat/"
 
 [project.optional-dependencies]
 community = [
@@ -48,6 +49,18 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/mcpcat"]
 
+# Explicit sdist allowlist: the default file selection sweeps untracked
+# working-tree files (local tool configs, build outputs) into the tarball.
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "src/mcpcat",
+    "tests",
+    "README.md",
+    "LICENSE",
+    "CONTRIBUTING.md",
+    "pyproject.toml",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
@@ -67,6 +80,9 @@ filterwarnings = [
     # would still surface. Format: action:message:category:module:lineno
     "ignore:websockets\\.legacy is deprecated:DeprecationWarning:websockets.legacy",
     "ignore:websockets\\.server\\.WebSocketServerProtocol is deprecated:DeprecationWarning:uvicorn.protocols.websockets.websockets_impl",
+    # Our own rename notice (mcpcat -> agentcat) fires on every import of the
+    # package; visibility is covered by tests/test_deprecation_notice.py.
+    "ignore:The 'mcpcat' package has been renamed:FutureWarning",
 ]
 
 [tool.mypy]

--- a/src/mcpcat/__init__.py
+++ b/src/mcpcat/__init__.py
@@ -8,6 +8,18 @@ from typing import Any
 
 __version__ = version("mcpcat")
 
+# FutureWarning (not DeprecationWarning): it must be visible by default to end
+# users of servers that embed this SDK, and it writes to stderr, which is safe
+# for stdio MCP transports.
+warnings.warn(
+    "The 'mcpcat' package has been renamed to 'agentcat'. This is the final "
+    "mcpcat release; it keeps working, but all new development ships in "
+    "'agentcat'. Migrate: pip install agentcat  (import agentcat; "
+    "agentcat.track(...)). See https://pypi.org/project/agentcat/",
+    FutureWarning,
+    stacklevel=2,
+)
+
 from mcpcat.modules.overrides.mcp_server import override_lowlevel_mcp_server
 from mcpcat.modules.session import get_session_info, new_session_id
 

--- a/tests/test_deprecation_notice.py
+++ b/tests/test_deprecation_notice.py
@@ -1,0 +1,31 @@
+"""The mcpcat -> agentcat rename notice must be visible with default warning
+filters (the reason it is a FutureWarning), and must never touch stdout,
+which would corrupt stdio MCP transports."""
+
+import subprocess
+import sys
+
+
+def _import_mcpcat_subprocess() -> subprocess.CompletedProcess:
+    # A fresh interpreter with default warning filters — pytest's own filter
+    # config must not leak into what real users see.
+    return subprocess.run(
+        [sys.executable, "-c", "import mcpcat"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_rename_notice_visible_by_default():
+    result = _import_mcpcat_subprocess()
+    assert result.returncode == 0
+    assert "FutureWarning" in result.stderr
+    assert "renamed to 'agentcat'" in result.stderr
+    assert "pip install agentcat" in result.stderr
+
+
+def test_rename_notice_never_writes_to_stdout():
+    result = _import_mcpcat_subprocess()
+    assert result.returncode == 0
+    assert result.stdout == ""


### PR DESCRIPTION
Same team, same product, same cats — new name. Companion to #35: that PR renames the SDK to [`agentcat`](https://pypi.org/project/agentcat/); this one stages the **last release of the `mcpcat` package name**, pointing everyone who lands here at the new one.

`mcpcat==0.1.15` — no functional or dependency changes, just the rename notice on every surface PyPI gives us:

- 📖 README banner with migration steps (renders on the PyPI page)
- 🏷️ `Development Status :: 7 - Inactive` classifier, `DEPRECATED` description prefix, and a Migration project URL — PyPI has no deprecate command, so metadata is the mechanism
- 📝 `FutureWarning` on import — visible under default filters, stderr-only so STDIO MCP servers are unaffected

**Nothing you have deployed will break — ever.** The `mcpcat` package, `api.mcpcat.io`, and `MCPCAT_API_URL` stay alive permanently — migrate on your own schedule; new features land only in `agentcat`. Full steps (and a paste-into-your-coding-agent prompt): [MIGRATION.md](https://github.com/MCPCat/mcpcat-python-sdk/blob/rebrand/agentcat/MIGRATION.md)

