### PR TITLE
fix(community-v3): inject tool context without deep-copying the tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcat"
-version = "1.0.0"
+version = "1.0.1"
 description = "Analytics tool for MCP (Model Context Protocol) servers and AI agents - tracks tool usage patterns and provides insights"
 authors = [
     { name = "AgentCat, Inc.", email = "support@agentcat.com" },

--- a/src/agentcat/modules/overrides/community_v3/middleware.py
+++ b/src/agentcat/modules/overrides/community_v3/middleware.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import copy
 from collections.abc import Sequence
 from datetime import datetime, timezone
+from importlib.metadata import version
 from typing import TYPE_CHECKING, Any
 
 import mcp.types as mt
@@ -33,6 +34,14 @@ from agentcat.types import EventType, AgentCatData, UnredactedEvent
 if TYPE_CHECKING:
     from fastmcp.server.middleware import CallNext, MiddlewareContext
     from fastmcp.tools.tool import Tool, ToolResult
+
+
+def _fastmcp_version() -> str:
+    """Best-effort resolved fastmcp version for diagnostics; never throws."""
+    try:
+        return version("fastmcp")
+    except Exception:
+        return "unknown"
 
 
 class AgentCatMiddleware:
@@ -387,10 +396,20 @@ class AgentCatMiddleware:
                 modified_tools.append(tool)
                 continue
 
+            # Only the parameters schema (a plain dict) is mutated below, so copy
+            # just that — never the whole Tool. Deep-copying the Tool drags in
+            # non-picklable fields it may hold (e.g. an httpx.AsyncClient with a
+            # threading.RLock on OpenAPI-generated tools), which raised
+            # "cannot pickle '_thread.RLock' object" and silently dropped context
+            # injection on every tools/list.
             try:
-                tool_copy = copy.deepcopy(tool)
+                tool_copy = tool.model_copy(
+                    update={"parameters": copy.deepcopy(getattr(tool, "parameters", None))}
+                )
             except Exception as e:
-                write_to_log(f"Error copying tool {tool.name}: {e}")
+                write_to_log(
+                    f"Error copying tool {tool.name} (fastmcp {_fastmcp_version()}): {e}"
+                )
                 modified_tools.append(tool)
                 continue
 

--- a/tests/community/test_community_v3_inject_context.py
+++ b/tests/community/test_community_v3_inject_context.py
@@ -1,0 +1,110 @@
+"""Regression tests for context injection in the FastMCP v3 middleware.
+
+Root cause reproduced here: OpenAPI-generated FastMCP v3 tools hold a reference
+to an ``httpx.AsyncClient``, which contains a ``threading.RLock``. The old
+implementation did ``copy.deepcopy(tool)`` to inject the ``context`` parameter,
+which raised ``TypeError: cannot pickle '_thread.RLock' object`` for every such
+tool on every ``tools/list`` — silently dropping context injection and flooding
+diagnostics with errors (observed for proj_3E07PMEFqZoF9sc6QeWvoaNbpet).
+"""
+
+import asyncio
+from datetime import datetime, timezone
+
+import copy
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from agentcat.modules.overrides.community_v3 import middleware as v3_middleware
+from agentcat.modules.overrides.community_v3.middleware import AgentCatMiddleware
+from agentcat.types import AgentCatData, AgentCatOptions, SessionInfo
+
+
+def _make_data() -> AgentCatData:
+    return AgentCatData(
+        project_id="test_project",
+        session_id="test_session",
+        session_info=SessionInfo(client_name="TestClient", client_version="1.0.0"),
+        last_activity=datetime.now(timezone.utc),
+        options=AgentCatOptions(custom_context_description="Why are you doing this?"),
+    )
+
+
+def _openapi_tool():
+    """An OpenAPI-generated tool holding an httpx client (non-deepcopyable)."""
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "rootly", "version": "1"},
+        "paths": {
+            "/severities": {
+                "get": {
+                    "operationId": "list_severities",
+                    "summary": "List severities",
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+    client = httpx.AsyncClient(base_url="https://example.com")
+    server = FastMCP.from_openapi(openapi_spec=spec, client=client, name="rootly")
+    tools = server.list_tools()
+    if asyncio.iscoroutine(tools):
+        tools = asyncio.run(tools)
+    return server, tools[0]
+
+
+def test_openapi_tool_is_not_deepcopyable():
+    """Guard: confirms the repro condition (deepcopy raises on the RLock)."""
+    _server, tool = _openapi_tool()
+    with pytest.raises(TypeError, match="cannot pickle '_thread.RLock' object"):
+        copy.deepcopy(tool)
+
+
+def test_context_injected_into_openapi_tool():
+    """Context injection must succeed even for non-deepcopyable tools."""
+    server, tool = _openapi_tool()
+    middleware = AgentCatMiddleware(_make_data(), server)
+
+    result = middleware._inject_context_into_tools([tool])
+
+    assert len(result) == 1
+    params = result[0].parameters
+    assert "context" in params["properties"], "context was not injected"
+    assert "context" in params["required"]
+    assert (
+        params["properties"]["context"]["description"] == "Why are you doing this?"
+    )
+
+
+def test_original_tool_not_mutated():
+    """Injection must not mutate the server's original tool object."""
+    server, tool = _openapi_tool()
+    middleware = AgentCatMiddleware(_make_data(), server)
+
+    middleware._inject_context_into_tools([tool])
+
+    assert "context" not in (tool.parameters or {}).get("properties", {})
+
+
+def test_copy_failure_logs_fastmcp_version(monkeypatch):
+    """If a tool still can't be copied, the log names the fastmcp version."""
+    from importlib.metadata import version
+
+    server, tool = _openapi_tool()
+    middleware = AgentCatMiddleware(_make_data(), server)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("copy blew up")
+
+    monkeypatch.setattr(v3_middleware.copy, "deepcopy", _boom)
+
+    logged: list[str] = []
+    monkeypatch.setattr(v3_middleware, "write_to_log", lambda msg: logged.append(msg))
+
+    result = middleware._inject_context_into_tools([tool])
+
+    assert result == [tool]  # falls back to the untouched original
+    assert len(logged) == 1
+    assert f"fastmcp {version('fastmcp')}" in logged[0]
+    assert "list_severities" in logged[0]

--- a/tests/community/test_community_v3_inject_context.py
+++ b/tests/community/test_community_v3_inject_context.py
@@ -12,13 +12,28 @@ import asyncio
 from datetime import datetime, timezone
 
 import copy
-import httpx
 import pytest
-from fastmcp import FastMCP
 
 from agentcat.modules.overrides.community_v3 import middleware as v3_middleware
 from agentcat.modules.overrides.community_v3.middleware import AgentCatMiddleware
 from agentcat.types import AgentCatData, AgentCatOptions, SessionInfo
+
+# The community_v3 middleware and FastMCP.from_openapi are FastMCP v3+ only. Skip
+# this module entirely when FastMCP is absent (test-without-fastmcp job) or on the
+# v2 compatibility matrix, without importing fastmcp at module top level.
+try:
+    import httpx
+    import fastmcp
+    from fastmcp import FastMCP
+
+    HAS_FASTMCP_V3 = int(fastmcp.__version__.split(".")[0]) >= 3
+except Exception:  # pragma: no cover - import guard
+    HAS_FASTMCP_V3 = False
+
+pytestmark = pytest.mark.skipif(
+    not HAS_FASTMCP_V3,
+    reason="Requires FastMCP v3+ (community_v3 OpenAPI middleware path)",
+)
 
 
 def _make_data() -> AgentCatData:


### PR DESCRIPTION
## Summary

- **Bug:** In the FastMCP v3 middleware, `_inject_context_into_tools` deep-copied the entire tool object on every `tools/list` request in order to add the AgentCat `context` parameter to its input schema. FastMCP v3 tools generated from an OpenAPI specification hold a reference to their `httpx.AsyncClient`, which contains a `threading.RLock`. Deep-copying that object raises `TypeError: cannot pickle '_thread.RLock' object`. The failure was caught and the tool returned unmodified, so **context injection was silently skipped** for every affected tool while the error was logged on each request — generating a high volume of SDK diagnostic errors.
- **Fix:** Only the `parameters` schema (a plain dictionary) is mutated during injection, so we now copy just that schema and reuse the rest of the tool by reference via `Tool.model_copy`. This avoids traversing non-copyable fields, restores context injection for OpenAPI-generated tools, and leaves the server's original tool objects unmutated.
- **Diagnostics:** The remaining copy-failure log line now records the resolved FastMCP version to aid future diagnosis.
- **Release:** Patch version bump `1.0.0` -> `1.0.1`.

## Impact

Customers running OpenAPI-generated FastMCP v3 servers on `agentcat==1.0.0` were not receiving tool-call context/intent capture, and their processes emitted a copy-failure log per tool on every `tools/list`. This restores the intended behavior and removes the error volume.

## Test plan

- [x] `uv run pytest tests/community/test_community_v3_inject_context.py -v` - new regression tests pass:
  - reproduces the RLock deep-copy failure on an OpenAPI-generated tool
  - verifies `context` is injected into the tool's parameters and marked required
  - verifies the server's original tool object is not mutated
  - verifies the fallback log line includes the resolved FastMCP version
- [x] `uv run pytest tests/community/ tests/test_context_parameters.py -q` - full community suite passes (no regressions)
- [x] Verified against **FastMCP 3.0.0b1** (pinned) and **FastMCP 3.4.4** (overlay): 85 passed on each